### PR TITLE
NOCOW & swap-in-ram fix.

### DIFF
--- a/0-preinstall.sh
+++ b/0-preinstall.sh
@@ -129,10 +129,16 @@ echo "-- Check for low memory systems <8G --"
 echo "--------------------------------------"
 TOTALMEM=$(cat /proc/meminfo | grep -i 'memtotal' | grep -o '[[:digit:]]*')
 if [[  $TOTALMEM -lt 8000000 ]]; then
-    dd if=/dev/zero of=/swapfile bs=1M count=2048 status=progress
-    chmod 600 /swapfile
-    mkswap /swapfile
-    swapon /swapfile
+    #Put swap into the actual system, not into RAM disk, otherwise there is no point in it, it'll cache RAM into RAM. So, /mnt/ everything.
+    mkdir /mnt/opt/swap #make a dir that we can apply NOCOW to to make it btrfs-friendly.
+    chattr +C /mnt/opt/swap #apply NOCOW, btrfs needs that.
+    dd if=/dev/zero of=/mnt/opt/swap/swapfile bs=1M count=2048 status=progress
+    chmod 600 /mnt/opt/swap/swapfile #set permissions.
+    chown root /mnt/opt/swap/swapfile
+    mkswap /mnt/opt/swap/swapfile
+    swapon /mnt/opt/swap/swapfile
+    #The line below is written to /mnt/ but doesn't contain /mnt/, since it's just / for the sysytem itself.
+    echo "/opt/swap/swapfile	none	swap	sw	0	0" >> /mnt/etc/fstab #Add swap to fstab, so it KEEPS working after installation.
 fi
 echo "--------------------------------------"
 echo "--   SYSTEM READY FOR 0-setup       --"


### PR DESCRIPTION
Swap is currently being put into RAM (oops!) so it doesn't work. We need to put it into /mnt/, i.e. onto the disk, which is kinda the point. Also, need to add a NOCOW fix mentioned and add the swap entry to fstab, so it keeps working after installation.