### PR TITLE
Fix for failing grub install

### DIFF
--- a/0-preinstall.sh
+++ b/0-preinstall.sh
@@ -106,6 +106,14 @@ echo "--------------------------------------"
 pacstrap /mnt base base-devel linux linux-firmware vim nano sudo archlinux-keyring wget libnewt --noconfirm --needed
 genfstab -U /mnt >> /mnt/etc/fstab
 echo "keyserver hkp://keyserver.ubuntu.com" >> /mnt/etc/pacman.d/gnupg/gpg.conf
+echo "--------------------------------------"
+echo "-- GRUB Bootloader Installation     --"
+echo "--------------------------------------"
+if [[ ! -d "/sys/firmware/efi" ]]; then
+    grub-install --boot-directory=/mnt/boot ${DISK}
+else
+    grub-install --efi-directory=/mnt/boot ${DISK}
+fi
 cp -R ${SCRIPT_DIR} /mnt/root/ArchTitus
 cp /etc/pacman.d/mirrorlist /mnt/etc/pacman.d/mirrorlist
 echo "--------------------------------------"

--- a/3-post-setup.sh
+++ b/3-post-setup.sh
@@ -9,14 +9,7 @@
 #-------------------------------------------------------------------------
 
 echo -e "\nFINAL SETUP AND CONFIGURATION"
-echo "--------------------------------------"
-echo "-- GRUB Bootloader Installation     --"
-echo "--------------------------------------"
-if [[ ! -d "/sys/firmware/efi" ]]; then
-    grub-install --boot-directory=/boot ${DISK}
-else
-    grub-install --efi-directory=/boot ${DISK}
-fi
+
 grub-mkconfig -o /boot/grub/grub.cfg
 
 # ------------------------------------------------------------------------


### PR DESCRIPTION
`Installing for i386-pc platform.`
`grub-install: error: install device isn't specified.`

grub couldn't be installed, because $DISK is only defined in 0-preinstall.sh.
I moved the grub install script from `3-post-setup.sh` to `0-preinstall.sh`, therefore it should work again.
This probably fixes #73