### PR TITLE
Wrong boot path for grub-install

### DIFF
--- a/0-preinstall.sh
+++ b/0-preinstall.sh
@@ -112,7 +112,7 @@ echo "--------------------------------------"
 echo "--GRUB BIOS Bootloader Install&Check--"
 echo "--------------------------------------"
 if [[ ! -d "/sys/firmware/efi" ]]; then
-    grub-install --boot-directory=/boot ${DISK}
+    grub-install --boot-directory=/mnt/boot ${DISK}
 fi
 echo "--------------------------------------"
 echo "-- Check for low memory systems <8G --"


### PR DESCRIPTION
The boot device should be `/mnt/boot` instead of `/boot`.
Probably fixes #80 