### PR TITLE
Many new features...

### DIFF
--- a/0-preinstall.sh
+++ b/0-preinstall.sh
@@ -7,17 +7,111 @@
 #  ██║  ██║██║  ██║╚██████╗██║  ██║   ██║   ██║   ██║   ╚██████╔╝███████║
 #  ╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝   ╚═╝   ╚═╝   ╚═╝    ╚═════╝ ╚══════╝
 #-------------------------------------------------------------------------
+
+function formatdisk {
+    # disk prep
+    sgdisk -Z ${1} # zap all on disk
+    sgdisk -a 2048 -o ${1} # new gpt disk 2048 alignment
+
+    # create partitions
+    sgdisk -n 1::+1M --typecode=1:ef02 --change-name=1:'BIOSBOOT' ${1} # partition 1 (BIOS Boot Partition)
+    sgdisk -n 2::+100M --typecode=2:ef00 --change-name=2:'BOOT' ${1} # partition 2 (UEFI Boot Partition)
+    sgdisk -n 3::-0 --typecode=3:8300 --change-name=3:'ROOT' ${1} # partition 3 (Root), default start, remaining
+    if [[ ! -d "/sys/firmware/efi" ]]; then
+        sgdisk -A 1:set:2 ${1}
+    fi
+
+    # make filesystems
+    if [[ ${1} =~ "nvme" ]]; then
+        mkfs.vfat -F32 -n "BOOT" "${1}p2"
+        mkfs.btrfs -L "ROOT" "${1}p3" -f
+        mount -t btrfs "${1}p3" /mnt
+    else
+        mkfs.vfat -F32 -n "BOOT" "${1}2"
+        mkfs.btrfs -L "ROOT" "${1}3" -f
+        mount -t btrfs "${1}3" /mnt
+    fi
+    ls /mnt #| xargs btrfs subvolume delete #ERROR: btrfs subvolumne delete: not enough arguments: 0 but at least 1 expected
+    btrfs subvolume create /mnt/@
+    umount /mnt
+       
+    ~/ArchTitus/x-mount.sh
+}
+
+
+function install {
+    ISO=$(curl -4 ifconfig.co/country-iso)
+    echo "-------------------------------------------------------------------------"
+    echo "--             Setting up $ISO mirrors for faster downloads              --"
+    echo "-------------------------------------------------------------------------"
+    pacman -S --noconfirm reflector rsync
+    cp /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.backup
+    echo "reflector is running, please wait..."
+    reflector -a 48 -c $ISO -f 5 -l 20 --sort rate --save /etc/pacman.d/mirrorlist
+    
+    # Add parallel downloading
+    sed -i 's/^#Para/Para/' /etc/pacman.conf
+
+    # Enable multilib
+    sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
+    pacman -Sy --noconfirm
+
+
+    echo "-------------------------------------------------------------------------"
+    echo "--                     Base Install on Main Drive                      --"
+    echo "-------------------------------------------------------------------------"
+    pacstrap /mnt linux base sudo networkmanager iwd --noconfirm --needed
+    genfstab -U /mnt >> /mnt/etc/fstab
+    #echo "keyserver hkp://keyserver.ubuntu.com" >> /mnt/etc/pacman.d/gnupg/gpg.conf
+    cp -R ${SCRIPT_DIR} /mnt/root/ArchTitus
+    cp /mnt/etc/pacman.d/mirrorlist /mnt/etc/pacman.d/mirrorlist.backup
+    cp /etc/pacman.d/mirrorlist /mnt/etc/pacman.d/mirrorlist	    
+    
+    #GRUB has been flaky...moving to chroot...BE SURE TO INSTALL GRUB IF YOU MOVE BACK
+    #echo "-------------------------------------------------------------------------"
+    #echo "--                      GRUB Bootloader Install                        --"
+    #echo "-------------------------------------------------------------------------"
+    #if [[ ! -d "/sys/firmware/efi" ]]; then
+    #    echo "Detected BIOS"
+    #    grub-install --boot-directory=/mnt/boot ${1}
+    #fi
+    #if [[ -d "/sys/firmware/efi" ]]; then
+    #    echo "Detected EFI"
+    #    grub-install --efi-directory=/mnt/boot --root-directory=/mnt
+    #fi
+    
+    echo "-------------------------------------------------------------------------"
+    echo "--                Check for low memory systems <8G                     --"
+    echo "-------------------------------------------------------------------------"
+    TOTALMEM=$(cat /proc/meminfo | grep -i 'memtotal' | grep -o '[[:digit:]]*')
+    if [[  $TOTALMEM -lt 8000000 ]]; then
+        #Put swap into the actual system, not into RAM disk, otherwise there is no point in it, it'll cache RAM into RAM. So, /mnt/ everything.
+        mkdir /mnt/opt/swap #make a dir that we can apply NOCOW to to make it btrfs-friendly.
+        chattr +C /mnt/opt/swap #apply NOCOW, btrfs needs that.
+        dd if=/dev/zero of=/mnt/opt/swap/swapfile bs=1M count=2048 status=progress
+        chmod 600 /mnt/opt/swap/swapfile #set permissions.
+        chown root /mnt/opt/swap/swapfile
+        mkswap /mnt/opt/swap/swapfile
+        swapon /mnt/opt/swap/swapfile
+        #The line below is written to /mnt/ but doesn't contain /mnt/, since it's just / for the sysytem itself.
+        echo "/opt/swap/swapfile	none	swap	sw	0	0" >> /mnt/etc/fstab #Add swap to fstab, so it KEEPS working after installation.
+    fi
+}
+
+
+# Misc Setup
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-echo "-------------------------------------------------"
-echo "Setting up mirrors for optimal download          "
-echo "-------------------------------------------------"
-iso=$(curl -4 ifconfig.co/country-iso)
 timedatectl set-ntp true
-pacman -S --noconfirm pacman-contrib terminus-font
+pacman -S --noconfirm terminus-font
 setfont ter-v22b
-sed -i 's/^#Para/Para/' /etc/pacman.conf
-pacman -S --noconfirm reflector rsync grub
-cp /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.backup
+
+# Read config file, if it exists
+configFileName=${HOME}/ArchTitus/install.conf
+if [ -e "$configFileName" ]; then
+	echo "Using configuration file $configFileName."
+	. $configFileName
+fi
+
 echo -e "-------------------------------------------------------------------------"
 echo -e "   █████╗ ██████╗  ██████╗██╗  ██╗████████╗██╗████████╗██╗   ██╗███████╗"
 echo -e "  ██╔══██╗██╔══██╗██╔════╝██║  ██║╚══██╔══╝██║╚══██╔══╝██║   ██║██╔════╝"
@@ -25,111 +119,61 @@ echo -e "  ███████║██████╔╝██║     ██�
 echo -e "  ██╔══██║██╔══██╗██║     ██╔══██║   ██║   ██║   ██║   ██║   ██║╚════██║"
 echo -e "  ██║  ██║██║  ██║╚██████╗██║  ██║   ██║   ██║   ██║   ╚██████╔╝███████║"
 echo -e "  ╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝   ╚═╝   ╚═╝   ╚═╝    ╚═════╝ ╚══════╝"
-echo -e "-------------------------------------------------------------------------"
-echo -e "-Setting up $iso mirrors for faster downloads"
-echo -e "-------------------------------------------------------------------------"
 
-reflector -a 48 -c $iso -f 5 -l 20 --sort rate --save /etc/pacman.d/mirrorlist
-mkdir /mnt
-
-
-echo -e "\nInstalling prereqs...\n$HR"
-pacman -S --noconfirm gptfdisk btrfs-progs
-
-echo "-------------------------------------------------"
-echo "-------select your disk to format----------------"
-echo "-------------------------------------------------"
-lsblk
-echo "Please enter disk to work on: (example /dev/sda)"
-read DISK
-echo "THIS WILL FORMAT AND DELETE ALL DATA ON THE DISK"
+# Get Disk
+if [ -e "$configFileName" ] && [ ! -z "$disk" ]; then
+    echo -e "-------------------------------------------------------------------------"
+    echo -e "-- User     - $username"
+    echo -e "-- Password - $password"  
+    echo -e "-- Host     - $hostname"
+    echo -e "-- Disk     - $disk"
+    echo -e "-------------------------------------------------------------------------"
+    echo -e "   *Blank values will be asked for during setup process..."
+    echo -e "-------------------------------------------------------------------------"
+    if [ "$password" == "*!*CHANGEME*!*...and-dont-store-in-plantext..." ]; then
+        while true; do
+	    read -s -p "Password for $username: " password
+	    echo
+	    read -s -p "Password for $username (again): " password2
+	    echo
+	    if [ "$password" = "$password2" ] && [ "$password" != "" ]; then
+	    	break
+	    fi
+	    echo "Please try again"
+	done
+	sed -i.bak "s/^\(password=\).*/\1$password/" $configFileName
+    fi
+    lsblk
+else
+    echo -e "-------------------------------------------------------------------------"
+    echo -e " Configuration File $configFileName not found..."
+    echo -e " Will ask for disk, user, password and hostname during setup process...  "
+    echo -e "-------------------------------------------------------------------------"
+    echo -e "------------------------select your disk to format-----------------------"
+    echo -e "-------------------------------------------------------------------------"
+    lsblk
+    echo "Please enter disk to format: (example /dev/sda)"
+    read disk
+    disk="${disk,,}"
+    if [[ "${disk}" != *"/dev/"* ]]; then
+        disk="/dev/${disk}"
+    fi
+    echo "disk=$disk" >> $configFileName
+fi
+echo "THIS WILL FORMAT AND DELETE ALL DATA ON ${disk}"
 read -p "are you sure you want to continue (Y/N):" formatdisk
 case $formatdisk in
-
-y|Y|yes|Yes|YES)
-echo "--------------------------------------"
-echo -e "\nFormatting disk...\n$HR"
-echo "--------------------------------------"
-
-# disk prep
-sgdisk -Z ${DISK} # zap all on disk
-sgdisk -a 2048 -o ${DISK} # new gpt disk 2048 alignment
-
-# create partitions
-sgdisk -n 1::+1M --typecode=1:ef02 --change-name=1:'BIOSBOOT' ${DISK} # partition 1 (BIOS Boot Partition)
-sgdisk -n 2::+100M --typecode=2:ef00 --change-name=2:'EFIBOOT' ${DISK} # partition 2 (UEFI Boot Partition)
-sgdisk -n 3::-0 --typecode=3:8300 --change-name=3:'ROOT' ${DISK} # partition 3 (Root), default start, remaining
-if [[ ! -d "/sys/firmware/efi" ]]; then
-    sgdisk -A 1:set:2 ${DISK}
-fi
-
-# make filesystems
-echo -e "\nCreating Filesystems...\n$HR"
-if [[ ${DISK} =~ "nvme" ]]; then
-mkfs.vfat -F32 -n "EFIBOOT" "${DISK}p2"
-mkfs.btrfs -L "ROOT" "${DISK}p3" -f
-mount -t btrfs "${DISK}p3" /mnt
-else
-mkfs.vfat -F32 -n "EFIBOOT" "${DISK}2"
-mkfs.btrfs -L "ROOT" "${DISK}3" -f
-mount -t btrfs "${DISK}3" /mnt
-fi
-ls /mnt | xargs btrfs subvolume delete
-btrfs subvolume create /mnt/@
-umount /mnt
-;;
-*)
-echo "Rebooting in 3 Seconds ..." && sleep 1
-echo "Rebooting in 2 Seconds ..." && sleep 1
-echo "Rebooting in 1 Second ..." && sleep 1
-reboot now
-;;
+    y|Y|yes|Yes|YES)
+        echo "-------------------------------------------------------------------------"
+        echo -e "\nFormatting ${disk}..."
+        echo "-------------------------------------------------------------------------"
+        formatdisk "${disk}"
+    ;;
+    *)
+        echo "Figure out your drive situation, and try again."
+        exit 1
+    ;;
 esac
 
-# mount target
-mount -t btrfs -o subvol=@ -L ROOT /mnt
-mkdir /mnt/boot
-mkdir /mnt/boot/efi
-mount -t vfat -L EFIBOOT /mnt/boot/
-
-if ! grep -qs '/mnt' /proc/mounts; then
-    echo "Drive is not mounted can not continue"
-    echo "Rebooting in 3 Seconds ..." && sleep 1
-    echo "Rebooting in 2 Seconds ..." && sleep 1
-    echo "Rebooting in 1 Second ..." && sleep 1
-    reboot now
-fi
-
-echo "--------------------------------------"
-echo "-- Arch Install on Main Drive       --"
-echo "--------------------------------------"
-pacstrap /mnt base base-devel linux linux-firmware vim nano sudo archlinux-keyring wget libnewt --noconfirm --needed
-genfstab -U /mnt >> /mnt/etc/fstab
-echo "keyserver hkp://keyserver.ubuntu.com" >> /mnt/etc/pacman.d/gnupg/gpg.conf
-cp -R ${SCRIPT_DIR} /mnt/root/ArchTitus
-cp /etc/pacman.d/mirrorlist /mnt/etc/pacman.d/mirrorlist
-echo "--------------------------------------"
-echo "--GRUB BIOS Bootloader Install&Check--"
-echo "--------------------------------------"
-if [[ ! -d "/sys/firmware/efi" ]]; then
-    grub-install --boot-directory=/mnt/boot ${DISK}
-fi
-echo "--------------------------------------"
-echo "-- Check for low memory systems <8G --"
-echo "--------------------------------------"
-TOTALMEM=$(cat /proc/meminfo | grep -i 'memtotal' | grep -o '[[:digit:]]*')
-if [[  $TOTALMEM -lt 8000000 ]]; then
-    #Put swap into the actual system, not into RAM disk, otherwise there is no point in it, it'll cache RAM into RAM. So, /mnt/ everything.
-    mkdir /mnt/opt/swap #make a dir that we can apply NOCOW to to make it btrfs-friendly.
-    chattr +C /mnt/opt/swap #apply NOCOW, btrfs needs that.
-    dd if=/dev/zero of=/mnt/opt/swap/swapfile bs=1M count=2048 status=progress
-    chmod 600 /mnt/opt/swap/swapfile #set permissions.
-    chown root /mnt/opt/swap/swapfile
-    mkswap /mnt/opt/swap/swapfile
-    swapon /mnt/opt/swap/swapfile
-    #The line below is written to /mnt/ but doesn't contain /mnt/, since it's just / for the sysytem itself.
-    echo "/opt/swap/swapfile	none	swap	sw	0	0" >> /mnt/etc/fstab #Add swap to fstab, so it KEEPS working after installation.
-fi
-echo "--------------------------------------"
-echo "--   SYSTEM READY FOR 1-setup       --"
-echo "--------------------------------------"
+install "${disk}"
+echo "ready for 'arch-chroot /mnt /root/ArchTitus/1-setup.sh'"

--- a/0-preinstall.sh
+++ b/0-preinstall.sh
@@ -132,10 +132,10 @@ if [ -e "$configFileName" ] && [ ! -z "$disk" ]; then
     echo -e "-------------------------------------------------------------------------"
     if [ "$password" == "*!*CHANGEME*!*...and-dont-store-in-plantext..." ]; then
         while true; do
-	    read -s -p "Password for $username: " password
-	    echo
-	    read -s -p "Password for $username (again): " password2
-	    echo
+            read -s -p "Password for $username: " password
+            echo
+            read -s -p "Password for $username (again): " password2
+            echo
 	    if [ "$password" = "$password2" ] && [ "$password" != "" ]; then
 	    	break
 	    fi

--- a/1-setup.sh
+++ b/1-setup.sh
@@ -136,7 +136,7 @@ PKGS_ARCH_DEFAULT=(
 #'qt5-virtualkeyboard' # Virtual keyboard for login screen (surface devices)
 'konsole' # KDE terminal
 'kate' # KDE text editor
-	'kompare' File comparison tool (also supports meld) (also supports kdiff3)
+	'kompare' # File comparison tool (also supports meld) (also supports kdiff3)
 	'meld'
 	'kdiff3'
 'ark' # KDE file archive tool

--- a/1-setup.sh
+++ b/1-setup.sh
@@ -85,6 +85,7 @@ echo "-------------------------------------------------------------------------"
 pacman -S plasma dolphin --noconfirm --needed
 pacman -S packagekit-qt5 --noconfirm --needed #needed for discover, which is in the plasma group
 pacman -S kdialog --noconfirm --needed #needed for some apps to display native kde dialogs
+pacman -S ffmpegthumbs --noconfirm --needed #needed for video thumbnails in dolphin, can turn off in dolphin options
 
 
 echo "-------------------------------------------------------------------------"
@@ -112,6 +113,7 @@ PKGS_ARCH_DEFAULT=(
 'cmatrix' # matrix screen
 'cronie' # schedule tasks/jobs
 'htop' # see running processes
+'dmidecode' # see system technical specs
 'lsof' # list open files for running Unix processes
 'nano' # a famous text editor...easy for newbies, not as powerful as vim
 'neofetch' # displays information about your computer

--- a/1-setup.sh
+++ b/1-setup.sh
@@ -131,6 +131,7 @@ PKGS_ARCH_DEFAULT=(
 'snapper' # managing BTRFS and LVM snapshots tool...(installed by snap-pac and snapper-gui-git as well)
 
 #...KDE...
+#'qt5-virtualkeyboard' # Virtual keyboard for login screen (surface devices)
 'konsole' # KDE terminal
 'kate' # KDE text editor
 'ark' # KDE file archive tool
@@ -197,8 +198,8 @@ PKGS_ARCH_DEFAULT=(
 'fuseiso' # mount ISO images
 
 #...SAMBA-WINDOWS NETWORK SHARE SUPPORT...
-'samba'
-'smbnetfs'
+#'samba'
+#'smbnetfs'
 
 #...UNNEEDED to explicitly install...
 'unzip' # file compression installed by other things when needed as a dependency

--- a/1-setup.sh
+++ b/1-setup.sh
@@ -105,31 +105,30 @@ PKGS_ARCH_DEFAULT=(
 'iptables-nft' # replaces iptables
 'traceroute' # track route taken by packets over an IP network
 'openbsd-netcat' # tcp/ip network tools
-'bind' #DNS tools
+'bind' # DNS tools
+'gufw' # manage netfilter firewall
 
 #...MAIN TOOLS...
-'cmatrix' # matix screen
+'cmatrix' # matrix screen
 'cronie' # schedule tasks/jobs
 'htop' # see running processes
 'lsof' # list open files for running Unix processes
-'nano' # a famous text editor
+'nano' # a famous text editor...easy for newbies, not as powerful as vim
 'neofetch' # displays information about your computer
-'openssh' # remote login with the SSH protocol
+'openssh' # remote login another system with the SSH protocol
 'os-prober' # detect other OSes on a set of drives (for grub)
-'vim' # a famous text editor
+'vim' # a famous text editor...hard for newbies
 'wget' # get files from web
-'git' # get files from web, development sync
+'git' # get files from web, think github or gitlab
 'bash-completion' # programmable completion for the bash shell
-'zsh' # command line intrepreter
+'zsh' # command line interpreter
 	'zsh-syntax-highlighting'
 	'zsh-autosuggestions'
 	'zsh-completions'
 'pacman-contrib' # scripts and tools for pacman systems
 'rsync' # sync files
 'reflector' # sort and filter pacman mirror list
-'snapper' # managing BTRFS and LVM snapshots tool...also installed by snap-pac and snapper-gui-git!!
-	    # btrfs can't create snapshots of a volume that also contains a swapfile. I fixed this by moving my swapfile to its own subvolume.
-'gufw' # manage netfilter firewall...added by me replacing ufw
+'snapper' # managing BTRFS and LVM snapshots tool...(installed by snap-pac and snapper-gui-git as well)
 
 #...KDE...
 'konsole' # KDE terminal
@@ -145,7 +144,7 @@ PKGS_ARCH_DEFAULT=(
 	'kimageformats'	   # dds, xcf, exr, psd, and more formats
 	'kipi-plugins'     # export to various online services
 	'kamera'           # imports from gphoto2 cameras
-'filelight' # KDE tool to view disk useage
+'filelight' # KDE tool to view disk use
 'spectacle' # KDE screenshot capture utility
 	'kipi-plugins' # export to various online services
 
@@ -159,31 +158,31 @@ PKGS_ARCH_DEFAULT=(
 'gimp' # Photo editing
 'jdk-openjdk' # Java 17
 'lutris' # gaming platform
-'okular'
-'qemu'
-'steam'
+'okular' # pdf viewer
+'qemu' # a hypervisor (virtual machines)
+'steam' # games
 'gamemode' # gaming optimizations
-'synergy'
-'virt-manager'
-'virt-viewer'
-'wine-gecko' #why not just wine?
-'wine-mono' #why not just wine?
-'winetricks' #why not just wine?
+'synergy' # share kebyard and mouse amung systems
+'virt-manager' # another hypervisor (create virtual machines)
+'virt-viewer' # another hypervisor (view virtual machines)
+'wine-gecko' # Wine's built-in replacement for Microsoft's Internet Explorer...(also installs wine)
+'wine-mono' # Wine's built-in replacement for Microsoft's .NET Framework...(also installs wine)
+'winetricks' # makes wine better...(also installs wine)
 
 #...AUDIO/SOUND SUPPORT...
-'alsa-plugins' #installed by steam
+'alsa-plugins' #(installed by steam)
 'alsa-utils'
-'pulseaudio' #installed as part of plasma-pa
+'pulseaudio' #(installed as part of plasma-pa)
 'pulseaudio-alsa'
 'pulseaudio-bluetooth'
 
 #...POWER/BATTERY/SUSPEND SUPPORT...
-'powerdevil' # KDE tool to manage power consumption...installed as part of plasma-desktop
+'powerdevil' # KDE tool to manage power consumption...(installed as part of plasma-desktop)
 
 #...BLUETOOTH SUPPORT...
 'bluedevil'
-'bluez' # bluetooth support...installed as part of bluedevil and powerdevil
-'bluez-libs'  #installed as part of networkmanager
+'bluez' # bluetooth support...(installed as part of bluedevil and powerdevil)
+'bluez-libs'  #(installed as part of networkmanager)
 'bluez-utils'
 
 #...PRINTER SUPPORT...
@@ -192,28 +191,28 @@ PKGS_ARCH_DEFAULT=(
 
 #...FILESYSTEM SUPPORT...
 'ntfs-3g' # NTFS support
-'dosfstools' #installed by k things
+'dosfstools' #(installed by kde things)
 'exfat-utils' # exfat support
-'btrfs-progs' #installed installed by snap-pac and snapper-gui-git MIGHT MIGHT Be installed by K!
+'btrfs-progs' #(installed by snap-pac and snapper-gui-git MIGHT MIGHT Be installed by kde things)
 'fuseiso' # mount ISO images
 
 #...SAMBA-WINDOWS NETWORK SHARE SUPPORT...
 'samba'
 'smbnetfs'
 
-#...UNNEEDED...
-'unzip' # file compression installed by other things when needed as a depenency
+#...UNNEEDED to explicitly install...
+'unzip' # file compression installed by other things when needed as a dependency
 'zip' # file compression
 'audiocd-kio' # Audio CDs
 'swtpm' # small tpm emulator
 'dialog' # Shows a dialog by command line
 'dtc'  # Device Tree Compilier (required for qemu and spike a ISA emulator)
 'egl-wayland' # graphics/nvidia
-'extra-cmake-modules' #I saw these get installed by some aur program, but no dep listed...
-'fuse2'  #installed as part of fuseiso
-'fuse3'  #installed as part of plasma-worksapce
-'gptfdisk' #DOES CFDISK work without it? YES  Installed as part of a bunch of K things
-'kcoreaddons' #installed as part of a bunch of k things
+'extra-cmake-modules' # installs by others things when needed as a dependency
+'fuse2'  #(installed as part of fuseiso)
+'fuse3'  #(installed as part of plasma-worksapce)
+'gptfdisk' #DOES CFDISK work without it? YES  (installed as part of a bunch of kde things)
+'kcoreaddons' #(installed as part of a bunch of kde things)
 'zeroconf-ioslave' # network Monitor for DNS-SD services for KDE
 'kvantum-qt5' 
 'linux-firmware'
@@ -223,10 +222,10 @@ PKGS_ARCH_DEFAULT=(
 'python-pyqt5'
 #CODECS
 'gst-libav' #installed as part of wine dxvk-bin I DID NOT INSTALL WINE..its DXVK-BIN
-'gst-plugins-good'  #installed by virt
+'gst-plugins-good'  #(installed by virt)
 'gst-plugins-ugly'
 'libdvdcss' # Portable abstraction library for DVD decryption
-'kcodecs' #installed as part of a bunch of k things 
+'kcodecs' #(installed as part of a bunch of kde things)
 )
 
 # Read config file, if it exists
@@ -343,7 +342,7 @@ if [ -e "$configFileName" ] && [ ! -z "$password" ] && [ "$password" != "*!*CHAN
 else
 	passwd $username
 	if [ "$password" != "*!*CHANGEME*!*...and-dont-store-in-plantext..." ]; then
-		echo "password=*!*CHANGEME*!*...and-dont-store-in-plantext..." >> ${HOME}/ArchTitus/install.conf
+		echo "password=*!*CHANGEME*!*...and-dont-store-in-plantext..." >> $configFileName
 	fi
 fi
 

--- a/1-setup.sh
+++ b/1-setup.sh
@@ -136,6 +136,9 @@ PKGS_ARCH_DEFAULT=(
 #'qt5-virtualkeyboard' # Virtual keyboard for login screen (surface devices)
 'konsole' # KDE terminal
 'kate' # KDE text editor
+	'kompare' File comparison tool (also supports meld) (also supports kdiff3)
+	'meld'
+	'kdiff3'
 'ark' # KDE file archive tool
 	'p7zip'      # 7Z format support 
 	'unrar'      # RAR decompression support

--- a/1-setup.sh
+++ b/1-setup.sh
@@ -7,247 +7,369 @@
 #  ██║  ██║██║  ██║╚██████╗██║  ██║   ██║   ██║   ██║   ╚██████╔╝███████║
 #  ╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝   ╚═╝   ╚═╝   ╚═╝    ╚═════╝ ╚══════╝
 #-------------------------------------------------------------------------
-echo "--------------------------------------"
-echo "--          Network Setup           --"
-echo "--------------------------------------"
-pacman -S networkmanager dhclient --noconfirm --needed
-systemctl enable --now NetworkManager
-echo "-------------------------------------------------"
-echo "Setting up mirrors for optimal download          "
-echo "-------------------------------------------------"
-pacman -S --noconfirm pacman-contrib curl
-pacman -S --noconfirm reflector rsync
-cp /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak
 
-nc=$(grep -c ^processor /proc/cpuinfo)
-echo "You have " $nc" cores."
-echo "-------------------------------------------------"
-echo "Changing the makeflags for "$nc" cores."
-TOTALMEM=$(cat /proc/meminfo | grep -i 'memtotal' | grep -o '[[:digit:]]*')
-if [[  $TOTALMEM -gt 8000000 ]]; then
-sed -i "s/#MAKEFLAGS=\"-j2\"/MAKEFLAGS=\"-j$nc\"/g" /etc/makepkg.conf
-echo "Changing the compression settings for "$nc" cores."
-sed -i "s/COMPRESSXZ=(xz -c -z -)/COMPRESSXZ=(xz -c -T $nc -z -)/g" /etc/makepkg.conf
-fi
-echo "-------------------------------------------------"
-echo "       Setup Language to US and set locale       "
-echo "-------------------------------------------------"
-sed -i 's/^#en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
-locale-gen
-timedatectl --no-ask-password set-timezone America/Chicago
-timedatectl --no-ask-password set-ntp 1
-localectl --no-ask-password set-locale LANG="en_US.UTF-8" LC_TIME="en_US.UTF-8"
+ISO=$(curl -4 ifconfig.co/country-iso)
+echo "-------------------------------------------------------------------------"
+echo "--                  Changes for optimal downloading                    --"
+echo "-------------------------------------------------------------------------"
+#commented because we just did this..
+#pacman -S --noconfirm reflector rsync
+#cp /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.backup
+#reflector -a 48 -c $ISO -f 5 -l 20 --sort rate --save /etc/pacman.d/mirrorlist
 
-# Set keymaps
-localectl --no-ask-password set-keymap us
-
-# Add sudo no password rights
-sed -i 's/^# %wheel ALL=(ALL) NOPASSWD: ALL/%wheel ALL=(ALL) NOPASSWD: ALL/' /etc/sudoers
-
-#Add parallel downloading
+# Add parallel downloading
 sed -i 's/^#Para/Para/' /etc/pacman.conf
 
-#Enable multilib
+# Enable multilib
 sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
 pacman -Sy --noconfirm
 
-echo -e "\nInstalling Base System\n"
 
-PKGS=(
-'mesa' # Essential Xorg First
-'xorg'
-'xorg-server'
-'xorg-apps'
-'xorg-drivers'
-'xorg-xkill'
-'xorg-xinit'
-'xterm'
-'plasma-desktop' # KDE Load second
-'alsa-plugins' # audio plugins
-'alsa-utils' # audio utils
-'ark' # compression
-'audiocd-kio' 
-'autoconf' # build
-'automake' # build
-'base'
-'bash-completion'
-'bind'
-'binutils'
-'bison'
-'bluedevil'
-'bluez'
-'bluez-libs'
-'bluez-utils'
-'breeze'
-'breeze-gtk'
-'bridge-utils'
-'btrfs-progs'
-'celluloid' # video players
-'cmatrix'
-'code' # Visual Studio code
-'cronie'
-'cups'
-'dialog'
-'discover'
-'dolphin'
-'dosfstools'
-'dtc'
-'efibootmgr' # EFI boot
-'egl-wayland'
-'exfat-utils'
-'extra-cmake-modules'
-'filelight'
-'flex'
-'fuse2'
-'fuse3'
-'fuseiso'
-'gamemode'
-'gcc'
-'gimp' # Photo editing
-'git'
-'gparted' # partition management
-'gptfdisk'
-'grub'
-'grub-customizer'
-'gst-libav'
-'gst-plugins-good'
-'gst-plugins-ugly'
-'gwenview'
-'haveged'
-'htop'
-'iptables-nft'
-'jdk-openjdk' # Java 17
-'kate'
-'kcodecs'
-'kcoreaddons'
-'kdeplasma-addons'
-'kde-gtk-config'
-'kinfocenter'
-'kscreen'
-'kvantum-qt5'
-'kitty'
-'konsole'
-'kscreen'
-'layer-shell-qt'
-'libdvdcss'
-'libnewt'
-'libtool'
-'linux'
-'linux-firmware'
-'linux-headers'
-'lsof'
-'lutris'
-'lzop'
-'m4'
-'make'
-'milou'
-'nano'
-'neofetch'
-'networkmanager'
-'ntfs-3g'
-'ntp'
-'okular'
-'openbsd-netcat'
-'openssh'
-'os-prober'
-'oxygen'
-'p7zip'
-'pacman-contrib'
-'patch'
-'picom'
-'pkgconf'
-'plasma-meta'
-'plasma-nm'
-'powerdevil'
+nc=$(grep -c ^processor /proc/cpuinfo)
+echo "-------------------------------------------------------------------------"
+echo "--               Changing the makeflags for "$nc" core(s).                 --"
+echo "-------------------------------------------------------------------------"
+TOTALMEM=$(cat /proc/meminfo | grep -i 'memtotal' | grep -o '[[:digit:]]*')
+if [[  $TOTALMEM -gt 8000000 ]]; then
+	sed -i "s/#MAKEFLAGS=\"-j2\"/MAKEFLAGS=\"-j$nc\"/g" /etc/makepkg.conf
+	echo "Changing the compression settings for "$nc" cores."
+	sed -i "s/COMPRESSXZ=(xz -c -z -)/COMPRESSXZ=(xz -c -T $nc -z -)/g" /etc/makepkg.conf
+fi
+
+
+echo "-------------------------------------------------------------------------"
+echo "--               Setup Language to US and set locale                   --"
+echo "-------------------------------------------------------------------------"
+timezone=$(curl -4 http://ip-api.com/line?fields=timezone)
+locale=en_US.UTF-8
+
+# Set locale
+sed -i s/^#$locale/$locale/ /etc/locale.gen
+locale-gen
+echo LANG=$locale  > /etc/locale.conf
+localectl --no-ask-password set-locale LANG=$locale LC_TIME=$locale
+
+# Set time
+timedatectl --no-ask-password set-ntp 1
+timedatectl --no-ask-password set-timezone $timezone
+#ln -sf /usr/share/zoneinfo/$timezone /etc/localtime
+
+# Set keymaps
+localectl --no-ask-password set-keymap us
+#echo "KEYMAP=US" > /etc/vconsole.conf
+    
+# Set timezone when NetworkManager connects to a network
+file=/etc/NetworkManager/dispatcher.d/09-timezone.sh
+cat <<EOF > $file
+#!/bin/sh
+case "\$2" in
+    up)
+    	timezone=\$(curl --fail http://ip-api.com/line?fields=timezone)
+        timedatectl --no-ask-password set-timezone \$timezone
+	#ln -sf /usr/share/zoneinfo/\$timezone /etc/localtime
+    ;;
+esac
+EOF
+chmod +x $file
+
+
+echo "-------------------------------------------------------------------------"
+echo "--                    X Display Manager Setup                          --"
+echo "-------------------------------------------------------------------------"
+pacman -S xorg --noconfirm --needed
+
+
+echo "-------------------------------------------------------------------------"
+echo "--                        KDE Plasma Setup                             --"
+echo "-------------------------------------------------------------------------"
+pacman -S plasma dolphin --noconfirm --needed
+pacman -S packagekit-qt5 --noconfirm --needed #needed for discover, which is in the plasma group
+pacman -S kdialog --noconfirm --needed #needed for some apps to display native kde dialogs
+
+
+echo "-------------------------------------------------------------------------"
+echo "--                  Installing Requested Packages                      --"
+echo "-------------------------------------------------------------------------"
+PKGS_ARCH_DEFAULT=(
+
+#...THEME...
+'terminus-font'
 'powerline-fonts'
-'print-manager'
-'pulseaudio'
+
+#...TOOLS...
+'usbutils' # query connected USB devices
+'ntp' # network time protocol reference implementation
+
+#...NETWORK TOOLS...
+'bridge-utils' # configuring etnernet bridge
+'iptables-nft' # replaces iptables
+'traceroute' # track route taken by packets over an IP network
+'openbsd-netcat' # tcp/ip network tools
+'bind' #DNS tools
+
+#...MAIN TOOLS...
+'cmatrix' # matix screen
+'cronie' # schedule tasks/jobs
+'htop' # see running processes
+'lsof' # list open files for running Unix processes
+'nano' # a famous text editor
+'neofetch' # displays information about your computer
+'openssh' # remote login with the SSH protocol
+'os-prober' # detect other OSes on a set of drives (for grub)
+'vim' # a famous text editor
+'wget' # get files from web
+'git' # get files from web, development sync
+'bash-completion' # programmable completion for the bash shell
+'zsh' # command line intrepreter
+	'zsh-syntax-highlighting'
+	'zsh-autosuggestions'
+	'zsh-completions'
+'pacman-contrib' # scripts and tools for pacman systems
+'rsync' # sync files
+'reflector' # sort and filter pacman mirror list
+'snapper' # managing BTRFS and LVM snapshots tool...also installed by snap-pac and snapper-gui-git!!
+	    # btrfs can't create snapshots of a volume that also contains a swapfile. I fixed this by moving my swapfile to its own subvolume.
+'gufw' # manage netfilter firewall...added by me replacing ufw
+
+#...KDE...
+'konsole' # KDE terminal
+'kate' # KDE text editor
+'ark' # KDE file archive tool
+	'p7zip'      # 7Z format support 
+	'unrar'      # RAR decompression support
+	'unarchiver' # RAR format support
+	'lzop'       # LZO format support
+	'lrzip'      # LRZ format support
+'gwenview' # KDE image viewer
+	'qt5-imageformats' # tiff, webp and more formats
+	'kimageformats'	   # dds, xcf, exr, psd, and more formats
+	'kipi-plugins'     # export to various online services
+	'kamera'           # imports from gphoto2 cameras
+'filelight' # KDE tool to view disk useage
+'spectacle' # KDE screenshot capture utility
+	'kipi-plugins' # export to various online services
+
+#...MISC/OTHER...
+'picom' # X compositor that may fix tearing issues
+'gparted' # graphical partition management
+'grub-customizer' # gui to customize grub
+'kitty' # terminal
+'celluloid' # video players
+'code' # Visual Studio code
+'gimp' # Photo editing
+'jdk-openjdk' # Java 17
+'lutris' # gaming platform
+'okular'
+'qemu'
+'steam'
+'gamemode' # gaming optimizations
+'synergy'
+'virt-manager'
+'virt-viewer'
+'wine-gecko' #why not just wine?
+'wine-mono' #why not just wine?
+'winetricks' #why not just wine?
+
+#...AUDIO/SOUND SUPPORT...
+'alsa-plugins' #installed by steam
+'alsa-utils'
+'pulseaudio' #installed as part of plasma-pa
 'pulseaudio-alsa'
 'pulseaudio-bluetooth'
+
+#...POWER/BATTERY/SUSPEND SUPPORT...
+'powerdevil' # KDE tool to manage power consumption...installed as part of plasma-desktop
+
+#...BLUETOOTH SUPPORT...
+'bluedevil'
+'bluez' # bluetooth support...installed as part of bluedevil and powerdevil
+'bluez-libs'  #installed as part of networkmanager
+'bluez-utils'
+
+#...PRINTER SUPPORT...
+'cups' # printer support
+'print-manager' # KDE tool to manage printers
+
+#...FILESYSTEM SUPPORT...
+'ntfs-3g' # NTFS support
+'dosfstools' #installed by k things
+'exfat-utils' # exfat support
+'btrfs-progs' #installed installed by snap-pac and snapper-gui-git MIGHT MIGHT Be installed by K!
+'fuseiso' # mount ISO images
+
+#...SAMBA-WINDOWS NETWORK SHARE SUPPORT...
+'samba'
+'smbnetfs'
+
+#...UNNEEDED...
+'unzip' # file compression installed by other things when needed as a depenency
+'zip' # file compression
+'audiocd-kio' # Audio CDs
+'swtpm' # small tpm emulator
+'dialog' # Shows a dialog by command line
+'dtc'  # Device Tree Compilier (required for qemu and spike a ISA emulator)
+'egl-wayland' # graphics/nvidia
+'extra-cmake-modules' #I saw these get installed by some aur program, but no dep listed...
+'fuse2'  #installed as part of fuseiso
+'fuse3'  #installed as part of plasma-worksapce
+'gptfdisk' #DOES CFDISK work without it? YES  Installed as part of a bunch of K things
+'kcoreaddons' #installed as part of a bunch of k things
+'zeroconf-ioslave' # network Monitor for DNS-SD services for KDE
+'kvantum-qt5' 
+'linux-firmware'
+'linux-headers'
 'python-notify2'
 'python-psutil'
 'python-pyqt5'
-'python-pip'
-'qemu'
-'rsync'
-'sddm'
-'sddm-kcm'
-'snapper'
-'spectacle'
-'steam'
-'sudo'
-'swtpm'
-'synergy'
-'systemsettings'
-'terminus-font'
-'traceroute'
-'ufw'
-'unrar'
-'unzip'
-'usbutils'
-'vim'
-'virt-manager'
-'virt-viewer'
-'wget'
-'which'
-'wine-gecko'
-'wine-mono'
-'winetricks'
-'xdg-desktop-portal-kde'
-'xdg-user-dirs'
-'zeroconf-ioslave'
-'zip'
-'zsh'
-'zsh-syntax-highlighting'
-'zsh-autosuggestions'
+#CODECS
+'gst-libav' #installed as part of wine dxvk-bin I DID NOT INSTALL WINE..its DXVK-BIN
+'gst-plugins-good'  #installed by virt
+'gst-plugins-ugly'
+'libdvdcss' # Portable abstraction library for DVD decryption
+'kcodecs' #installed as part of a bunch of k things 
 )
 
-for PKG in "${PKGS[@]}"; do
-    echo "INSTALLING: ${PKG}"
-    sudo pacman -S "$PKG" --noconfirm --needed
-done
+# Read config file, if it exists
+configFileName=${HOME}/ArchTitus/install.conf
+if [ -e "$configFileName" ]; then
+	echo "Using configuration file $configFileName."
+	. $configFileName
+fi
 
-#
-# determine processor type and install microcode
-# 
+# install default or user specified packages (if they exist)
+if [ ${#PKGS_ARCH[@]} -eq 0 ]; then
+	echo "installing arch default packages"
+	for PKG in "${PKGS_ARCH_DEFAULT[@]}"; do
+	    echo "INSTALLING ARCH DEFAULT PACKAGE: ${PKG}"
+	    pacman -S "$PKG" --noconfirm --needed
+	    break
+	done
+else
+	echo "installing arch user specified packages"
+	for PKG in "${PKGS_ARCH[@]}"; do
+	    echo "INSTALLING ARCH USER SPECIFIED PACKAGE: ${PKG}"
+	    pacman -S "$PKG" --noconfirm --needed
+	    break
+	done
+fi
+
+echo "-------------------------------------------------------------------------"
+echo "--                 Installing Processor Microcode                      --"
+echo "-------------------------------------------------------------------------"
 proc_type=$(lscpu | awk '/Vendor ID:/ {print $3}')
 case "$proc_type" in
 	GenuineIntel)
-		print "Installing Intel microcode"
+		echo "Installing Intel microcode"
 		pacman -S --noconfirm intel-ucode
 		proc_ucode=intel-ucode.img
 		;;
 	AuthenticAMD)
-		print "Installing AMD microcode"
+		echo "Installing AMD microcode"
 		pacman -S --noconfirm amd-ucode
 		proc_ucode=amd-ucode.img
 		;;
 esac	
 
-# Graphics Drivers find and install
+
+echo "-------------------------------------------------------------------------"
+echo "--                   Installing Grapics Drivers                        --"
+echo "-------------------------------------------------------------------------"
 if lspci | grep -E "NVIDIA|GeForce"; then
-    pacman -S nvidia --noconfirm --needed
+	echo "Installing NVIDIA Drivers."
+    	pacman -S nvidia --noconfirm --needed
 	nvidia-xconfig
 elif lspci | grep -E "Radeon"; then
-    pacman -S xf86-video-amdgpu --noconfirm --needed
+    	echo "Installing ATI/AMD Drivers."
+	pacman -S xf86-video-amdgpu --noconfirm --needed
 elif lspci | grep -E "Integrated Graphics Controller"; then
-    pacman -S libva-intel-driver libvdpau-va-gl lib32-vulkan-intel vulkan-intel libva-intel-driver libva-utils --needed --noconfirm
+    	echo "Installing Intel Integrated Drivers."
+    	pacman -S libva-intel-driver libvdpau-va-gl lib32-vulkan-intel vulkan-intel libva-intel-driver libva-utils --needed --noconfirm
 fi
 
-echo -e "\nDone!\n"
-if ! source install.conf; then
-	read -p "Please enter username:" username
-echo "username=$username" >> ${HOME}/ArchTitus/install.conf
+hypervisor=$(systemd-detect-virt)
+case $hypervisor in
+kvm )		echo "Installing KVM guest tools."
+		pacman -S qemu-guest-agent --noconfirm --needed
+		systemctl enable qemu-guest-agent
+		;;
+vmware )   	echo "Installing VMWare guest tools."
+	    	pacman -S open-vm-tools --noconfirm --needed
+	    	systemctl enable vmtoolsd
+	    	systemctl enable vmware-vmblock-fuse
+	    	;;
+oracle )    	echo "Installing VirtualBox guest tools."
+	    	pacman -S virtualbox-guest-utils --noconfirm --needed
+		systemctl enable vboxservice
+	    	;;
+microsoft ) 	echo "Installing Hyper-V guest tools."
+		pacman -S hyperv --noconfirm --needed
+	    	systemctl enable hv_fcopy_daemon
+	    	systemctl enable hv_kvp_daemon
+	    	systemctl enable hv_vss_daemon
+	    	;;
+esac
+
+
+echo "-------------------------------------------------------------------------"
+echo "--                            Setup User                               --"
+echo "-------------------------------------------------------------------------"
+# Read config file, if it exists
+configFileName=${HOME}/ArchTitus/install.conf
+if [ -e "$configFileName" ]; then
+	echo "Using configuration file $configFileName."
+	. $configFileName
 fi
-if [ $(whoami) = "root"  ];
-then
-    useradd -m -G wheel,libvirt -s /bin/bash $username 
-	passwd $username
-	cp -R /root/ArchTitus /home/$username/
-    chown -R $username: /home/$username/ArchTitus
-	read -p "Please name your machine:" nameofmachine
-	echo $nameofmachine > /etc/hostname
+
+# Get username
+if [ -e "$configFileName" ] && [ ! -z "$username" ]; then
+	echo "Creating user - $username."
 else
-	echo "You are already a user proceed with aur installs"
+	read -p "Please enter username:" username
+	echo "username=$username" >> $configFileName
 fi
 
+# Add user
+egrep -i "libvirt" /etc/group;
+if [ $? -eq 0 ]; then
+	useradd -m -G wheel,libvirt -s /bin/bash $username
+else
+	useradd -m -G wheel -s /bin/bash $username
+fi
+
+# Set user password
+if [ -e "$configFileName" ] && [ ! -z "$password" ] && [ "$password" != "*!*CHANGEME*!*...and-dont-store-in-plantext..." ]; then
+	echo "Got a password for $username."
+	echo "$username:$password" | chpasswd
+	echo "Masking password in config file."
+	sed -i.bak 's/^\(password=\).*/\1*!*CHANGEME*!*...and-dont-store-in-plantext.../' $configFileName
+else
+	passwd $username
+	if [ "$password" != "*!*CHANGEME*!*...and-dont-store-in-plantext..." ]; then
+		echo "password=*!*CHANGEME*!*...and-dont-store-in-plantext..." >> ${HOME}/ArchTitus/install.conf
+	fi
+fi
+
+# Set hostname
+if [ -e "$configFileName" ] && [ ! -z "$hostname" ]; then
+	echo "hostname: $hostname"
+else
+	read -p "Please name your machine:" hostname
+	echo "hostname=$hostname" >> $configFileName
+fi
+echo $hostname > /etc/hostname
+
+# Set hosts file.
+cat <<EOF > /etc/hosts
+127.0.0.1   localhost
+::1         localhost
+127.0.1.1   $hostname.localdomain   $hostname
+EOF
+
+# Copy this script to new user home directory
+cp -R /root/ArchTitus /home/$username/
+chown -R $username: /home/$username/ArchTitus
+
+# Add sudo no password rights
+sed -i 's/^# %wheel ALL=(ALL) NOPASSWD: ALL/%wheel ALL=(ALL) NOPASSWD: ALL/' /etc/sudoers
+
+echo "ready for 'arch-chroot /mnt /usr/bin/runuser -u $username -- /home/$username/ArchTitus/2-user.sh'"

--- a/1-setup.sh
+++ b/1-setup.sh
@@ -242,14 +242,12 @@ if [ ${#PKGS_ARCH[@]} -eq 0 ]; then
 	for PKG in "${PKGS_ARCH_DEFAULT[@]}"; do
 	    echo "INSTALLING ARCH DEFAULT PACKAGE: ${PKG}"
 	    pacman -S "$PKG" --noconfirm --needed
-	    break
 	done
 else
 	echo "installing arch user specified packages"
 	for PKG in "${PKGS_ARCH[@]}"; do
 	    echo "INSTALLING ARCH USER SPECIFIED PACKAGE: ${PKG}"
 	    pacman -S "$PKG" --noconfirm --needed
-	    break
 	done
 fi
 

--- a/2-user.sh
+++ b/2-user.sh
@@ -108,8 +108,8 @@ if [ ! -z "${openWeatherMapCityId}" ]; then
     sudo make install
 
     # Configure KDE and weather plasmoids
-    file1=/home/titus/.config/plasma-org.kde.plasma.desktop-appletsrc
-    file2=/home/titus/.config/plasma_calendar_holiday_regions
+    file1=${HOME}/.config/plasma-org.kde.plasma.desktop-appletsrc
+    file2=${HOME}/.config/plasma_calendar_holiday_regions
 
     sed -i 's/plugin=org.kde.plasma.digitalclock/plugin=org.kde.plasma.eventcalendar/g' $file1
     sed -i 's/AppletOrder=34;4;5;6;7;18;19/AppletOrder=34;4;5;6;44;7;18;19/g' $file1

--- a/2-user.sh
+++ b/2-user.sh
@@ -84,6 +84,45 @@ else
 	done
 fi
 
+
+echo "-------------------------------------------------------------------------"
+echo "--                        Setup User Theme                             --"
+echo "-------------------------------------------------------------------------"
+# Zsh syntax highlighting
+cd ~
+touch "$HOME/.cache/zshhistory"
+git clone "https://github.com/ChrisTitusTech/zsh"
+git clone --depth=1 https://github.com/romkatv/powerlevel10k.git $HOME/powerlevel10k
+ln -s "$HOME/zsh/.zshrc" $HOME/.zshrc
+
+# KDE config
+sudo pacman -S python-pip --noconfirm --needed
+export PATH=$PATH:~/.local/bin
+cp -r $HOME/ArchTitus/dotfiles/* $HOME/.config/
+pip install konsave
+konsave -i $HOME/ArchTitus/kde.knsv
+sleep 1
+konsave -a kde
+
+sudo systemctl enable sddm.service
+sudo bash -c 'cat <<EOF > /etc/sddm.conf
+[Theme]
+Current=Nordic
+[General]
+InputMethod=qtvirtualkeyboard
+EOF
+'
+
+# ffmpegthumbs (video thumbnails) for Dolphin
+# This is dolphin defaults + ffmpegthumbs
+echo "[PreviewSettings]" >> $HOME/.config/dolphinrc
+echo "Plugins=appimagethumbnail,audiothumbnail,comicbookthumbnail,cursorthumbnail,djvuthumbnail,ebookthumbnail,exrthumbnail,directorythumbnail,fontthumbnail,imagethumbnail,jpegthumbnail,kraorathumbnail,windowsexethumbnail,windowsimagethumbnail,opendocumentthumbnail,svgthumbnail,textthumbnail,ffmpegthumbs" >> $HOME/.config/dolphinrc
+echo "[PreviewSettings]" >> $HOME/.config/kdeglobals
+echo "MaximumRemoteSize=10485758951424" >> $HOME/.config/kdeglobals
+
+#echo "[General]" >> $HOME/.config/dolphinrc
+#echo "RememberOpenedTabs=false" >> $HOME/.config/dolphinrc
+
 # install optional weather package if configured
 if [ ! -z "${openWeatherMapCityId}" ]; then
     if [ -z "${openWeatherMapCityAlias}" ]; then
@@ -158,45 +197,6 @@ if [ ! -z "${openWeatherMapCityId}" ]; then
 else
     echo "no weather configured"
 fi
-
-
-echo "-------------------------------------------------------------------------"
-echo "--                        Setup User Theme                             --"
-echo "-------------------------------------------------------------------------"
-# Zsh syntax highlighting
-cd ~
-touch "$HOME/.cache/zshhistory"
-git clone "https://github.com/ChrisTitusTech/zsh"
-git clone --depth=1 https://github.com/romkatv/powerlevel10k.git $HOME/powerlevel10k
-ln -s "$HOME/zsh/.zshrc" $HOME/.zshrc
-
-# KDE config
-sudo pacman -S python-pip --noconfirm --needed
-export PATH=$PATH:~/.local/bin
-cp -r $HOME/ArchTitus/dotfiles/* $HOME/.config/
-pip install konsave
-konsave -i $HOME/ArchTitus/kde.knsv
-sleep 1
-konsave -a kde
-
-sudo systemctl enable sddm.service
-sudo bash -c 'cat <<EOF > /etc/sddm.conf
-[Theme]
-Current=Nordic
-[General]
-InputMethod=qtvirtualkeyboard
-EOF
-'
-
-# ffmpegthumbs (video thumbnails) for Dolphin
-# This is dolphin defaults + ffmpegthumbs
-echo "[PreviewSettings]" >> $HOME/.config/dolphinrc
-echo "Plugins=appimagethumbnail,audiothumbnail,comicbookthumbnail,cursorthumbnail,djvuthumbnail,ebookthumbnail,exrthumbnail,directorythumbnail,fontthumbnail,imagethumbnail,jpegthumbnail,kraorathumbnail,windowsexethumbnail,windowsimagethumbnail,opendocumentthumbnail,svgthumbnail,textthumbnail,ffmpegthumbs" >> $HOME/.config/dolphinrc
-echo "[PreviewSettings]" >> $HOME/.config/kdeglobals
-echo "MaximumRemoteSize=10485758951424" >> $HOME/.config/kdeglobals
-
-#echo "[General]" >> $HOME/.config/dolphinrc
-#echo "RememberOpenedTabs=false" >> $HOME/.config/dolphinrc
 
 # In case someone installs syncthing
 username=$(whoami)

--- a/2-user.sh
+++ b/2-user.sh
@@ -14,7 +14,7 @@ echo "-------------------------------------------------------------------------"
 # Make sure these packages are installed for installing AUR manager
 sudo pacman -S git base-devel --noconfirm --needed
 
-# Download and Install yay
+# Download and Install yay AUR manager
 cd ~
 git clone "https://aur.archlinux.org/yay.git"
 cd ${HOME}/yay

--- a/2-user.sh
+++ b/2-user.sh
@@ -111,4 +111,16 @@ Current=Nordic
 EOF
 '
 
+# In case someone uses 
+'$HOME/.config/dolphinrc'
+
+# In case someone installs syncthing
+username=$(whoami)
+systemctl enable syncthing@$username.service
+
+# In case someone doesn't delete ffmpegthumbs (video thumbnails)
+# This is dolphin defaults + ffmpegthumbs
+echo "[PreviewSettings]" >> $HOME/.config/dolphinrc
+echo "Plugins=appimagethumbnail,audiothumbnail,comicbookthumbnail,cursorthumbnail,djvuthumbnail,ebookthumbnail,exrthumbnail,directorythumbnail,fontthumbnail,imagethumbnail,jpegthumbnail,kraorathumbnail,windowsexethumbnail,windowsimagethumbnail,opendocumentthumbnail,svgthumbnail,textthumbnail,ffmpegthumbs" >> $HOME/.config/dolphinrc
+
 echo "ready for 'arch-chroot /mnt /root/ArchTitus/3-post-setup.sh'"

--- a/2-user.sh
+++ b/2-user.sh
@@ -108,6 +108,8 @@ sudo systemctl enable sddm.service
 sudo bash -c 'cat <<EOF > /etc/sddm.conf
 [Theme]
 Current=Nordic
+[General]
+InputMethod=qtvirtualkeyboard
 EOF
 '
 
@@ -122,5 +124,10 @@ systemctl enable syncthing@$username.service
 # This is dolphin defaults + ffmpegthumbs
 echo "[PreviewSettings]" >> $HOME/.config/dolphinrc
 echo "Plugins=appimagethumbnail,audiothumbnail,comicbookthumbnail,cursorthumbnail,djvuthumbnail,ebookthumbnail,exrthumbnail,directorythumbnail,fontthumbnail,imagethumbnail,jpegthumbnail,kraorathumbnail,windowsexethumbnail,windowsimagethumbnail,opendocumentthumbnail,svgthumbnail,textthumbnail,ffmpegthumbs" >> $HOME/.config/dolphinrc
+echo "[PreviewSettings]" >> $HOME/.config/kdeglobals
+echo "MaximumRemoteSize=10485758951424" >> $HOME/.config/kdeglobals
+
+#echo "[General]" >> $HOME/.config/dolphinrc
+#echo "RememberOpenedTabs=false" >> $HOME/.config/dolphinrc
 
 echo "ready for 'arch-chroot /mnt /root/ArchTitus/3-post-setup.sh'"

--- a/3-post-setup.sh
+++ b/3-post-setup.sh
@@ -8,50 +8,47 @@
 #  ╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝   ╚═╝   ╚═╝   ╚═╝    ╚═════╝ ╚══════╝
 #-------------------------------------------------------------------------
 
-echo -e "\nFINAL SETUP AND CONFIGURATION"
-echo "--------------------------------------"
-echo "-- GRUB EFI Bootloader Install&Check--"
-echo "--------------------------------------"
-if [[ -d "/sys/firmware/efi" ]]; then
-    grub-install --efi-directory=/boot ${DISK}
-fi
-grub-mkconfig -o /boot/grub/grub.cfg
+echo "-------------------------------------------------------------------------"
+echo "--                          GRUB Bootloader                            --"
+echo "-------------------------------------------------------------------------"
+    ~/ArchTitus/x-bootloader.sh
 
-# ------------------------------------------------------------------------
 
-echo -e "\nEnabling Login Display Manager"
-systemctl enable sddm.service
-echo -e "\nSetup SDDM Theme"
-cat <<EOF > /etc/sddm.conf
-[Theme]
-Current=Nordic
-EOF
-
-# ------------------------------------------------------------------------
-
-echo -e "\nEnabling essential services"
-
-systemctl enable cups.service
-ntpd -qg
-systemctl enable ntpd.service
-systemctl disable dhcpcd.service
-systemctl stop dhcpcd.service
-systemctl enable NetworkManager.service
-systemctl enable bluetooth
-echo "
-###############################################################################
-# Cleaning
-###############################################################################
-"
-# Remove no password sudo rights
+echo "-------------------------------------------------------------------------"
+echo "--                         Cleaning Up / Misc                          --"
+echo "-------------------------------------------------------------------------"
+# Remove no password sudo rights granted previously
 sed -i 's/^%wheel ALL=(ALL) NOPASSWD: ALL/# %wheel ALL=(ALL) NOPASSWD: ALL/' /etc/sudoers
 # Add sudo rights
 sed -i 's/^# %wheel ALL=(ALL) ALL/%wheel ALL=(ALL) ALL/' /etc/sudoers
 
-# Replace in the same state
+# Cleanup unused packages
+pacman -Rsc --noconfirm "$(pacman -Qqdt)"
+
+# Enable btrfs snapshots
+snapper -c root create-config /
+
+
+# Enable services
+systemctl disable dhcpcd.service
+systemctl stop dhcpcd.service
+
+systemctl enable sddm.service
+
+ntpd -qg #netowrk time sync
+systemctl enable ntpd.service
+
+systemctl enable cups.service
+systemctl enable bluetooth
+
+systemctl enable smb.service
+systemctl enable nmb.service
+systemctl enable NetworkManager.service
+systemctl enable NetworkManager-dispatcher.service
+
+# change directory back
 cd $pwd
-echo "
-###############################################################################
-# Done - Please Eject Install Media and Reboot
-###############################################################################
-"
+
+echo "-------------------------------------------------------------------------"
+echo "--          Done - Please Eject Install Media and Reboot               --"
+echo "-------------------------------------------------------------------------"

--- a/3-post-setup.sh
+++ b/3-post-setup.sh
@@ -39,6 +39,7 @@ systemctl enable bluetooth
 
 systemctl enable smb.service
 systemctl enable nmb.service
+systemctl enable avahi-daemon.service
 
 systemctl enable NetworkManager.service
 systemctl enable NetworkManager-dispatcher.service

--- a/3-post-setup.sh
+++ b/3-post-setup.sh
@@ -28,7 +28,6 @@ pacman -Rsc --noconfirm "$(pacman -Qqdt)"
 # Enable btrfs snapshots
 snapper -c root create-config /
 
-
 # Enable services
 systemctl disable dhcpcd.service
 systemctl stop dhcpcd.service
@@ -43,12 +42,11 @@ systemctl enable bluetooth
 
 systemctl enable smb.service
 systemctl enable nmb.service
+
 systemctl enable NetworkManager.service
 systemctl enable NetworkManager-dispatcher.service
 
 # change directory back
 cd $pwd
 
-echo "-------------------------------------------------------------------------"
-echo "--          Done - Please Eject Install Media and Reboot               --"
-echo "-------------------------------------------------------------------------"
+echo "Done!"

--- a/3-post-setup.sh
+++ b/3-post-setup.sh
@@ -25,9 +25,6 @@ sed -i 's/^# %wheel ALL=(ALL) ALL/%wheel ALL=(ALL) ALL/' /etc/sudoers
 # Cleanup unused packages
 pacman -Rsc --noconfirm "$(pacman -Qqdt)"
 
-# Enable btrfs snapshots
-snapper -c root create-config /
-
 # Enable services
 systemctl disable dhcpcd.service
 systemctl stop dhcpcd.service
@@ -45,6 +42,9 @@ systemctl enable nmb.service
 
 systemctl enable NetworkManager.service
 systemctl enable NetworkManager-dispatcher.service
+
+# Enable btrfs snapshots
+snapper -c root create-config /
 
 # change directory back
 cd $pwd

--- a/archtitus.sh
+++ b/archtitus.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-    bash 0-preinstall.sh
-    arch-chroot /mnt /root/ArchTitus/1-setup.sh
-    source /mnt/root/ArchTitus/install.conf
-    arch-chroot /mnt /usr/bin/runuser -u $username -- /home/$username/ArchTitus/2-user.sh
-    arch-chroot /mnt /root/ArchTitus/3-post-setup.sh
+read -t 60 -p 'Welcome! Please wait 60 seconds for lingering tasks (time set, reflector, graphical interface...) to complete. Press enter to skip.'
+
+status=$?
+cmd="bash 0-preinstall.sh"
+$cmd
+status=$? && [ $status -eq 0 ] || exit
+
+arch-chroot /mnt /root/ArchTitus/1-setup.sh
+source /mnt/root/ArchTitus/install.conf #read config file
+arch-chroot /mnt /usr/bin/runuser -u $username -- /home/$username/ArchTitus/2-user.sh
+arch-chroot /mnt /root/ArchTitus/3-post-setup.sh

--- a/archtitus.sh
+++ b/archtitus.sh
@@ -11,3 +11,7 @@ arch-chroot /mnt /root/ArchTitus/1-setup.sh
 source /mnt/root/ArchTitus/install.conf #read config file
 arch-chroot /mnt /usr/bin/runuser -u $username -- /home/$username/ArchTitus/2-user.sh
 arch-chroot /mnt /root/ArchTitus/3-post-setup.sh
+
+echo "-------------------------------------------------------------------------"
+echo "--          Done - Please Eject Install Media and Reboot               --"
+echo "-------------------------------------------------------------------------"

--- a/install.example.conf
+++ b/install.example.conf
@@ -3,7 +3,7 @@ username=titus
 password=1234
 hostname=host
 
-PKGS_AUR_DEFAULT=(
+PKGS_AUR=(
 'brave-bin' # Brave Browser
 'dxvk-bin' # DXVK DirectX to Vulcan
 'github-desktop-bin' # Github Desktop sync
@@ -14,7 +14,7 @@ PKGS_AUR_DEFAULT=(
 'snapper-gui-git' # a tool of managing snapshots of Btrfs subvolumes and LVM volumes
 )
 
-PKGS_ARCH_DEFAULT=(
+PKGS_ARCH=(
 
 #...THEME...
 'terminus-font'

--- a/install.example.conf
+++ b/install.example.conf
@@ -1,3 +1,4 @@
+disk=/dev/sda
 hostname=host
 username=titus
 password=1234

--- a/install.example.conf
+++ b/install.example.conf
@@ -3,6 +3,13 @@ username=titus
 password=1234
 hostname=host
 
+# Configuring this section enables showing weather on the taskbar
+# and forecasts on the calendar
+# Go to 'https://openweathermap.org/find' to get your City ID and Alias
+# This example is for Chicago.
+#openWeatherMapCityId=4887398
+#openWeatherMapCityAlias="Chicago, US"
+
 PKGS_AUR=(
 'brave-bin' # Brave Browser
 'dxvk-bin' # DXVK DirectX to Vulcan
@@ -33,15 +40,16 @@ PKGS_ARCH=(
 'gufw' # manage netfilter firewall
 
 #...MAIN TOOLS...
-'cmatrix' # matix screen
+'cmatrix' # matrix screen
 'cronie' # schedule tasks/jobs
 'htop' # see running processes
+'dmidecode' # see system technical specs
 'lsof' # list open files for running Unix processes
-'nano' # a famous text editor
+'nano' # a famous text editor...easy for newbies, not as powerful as vim
 'neofetch' # displays information about your computer
 'openssh' # remote login another system with the SSH protocol
 'os-prober' # detect other OSes on a set of drives (for grub)
-'vim' # a famous text editor
+'vim' # a famous text editor...hard for newbies
 'wget' # get files from web
 'git' # get files from web, think github or gitlab
 'bash-completion' # programmable completion for the bash shell
@@ -52,12 +60,15 @@ PKGS_ARCH=(
 'pacman-contrib' # scripts and tools for pacman systems
 'rsync' # sync files
 'reflector' # sort and filter pacman mirror list
-'snapper' # managing BTRFS and LVM snapshots tool...also installed by snap-pac and snapper-gui-git
-	      # btrfs can't create snapshots of a volume that also contains a swapfile. I fixed this by moving my swapfile to its own subvolume.
+'snapper' # managing BTRFS and LVM snapshots tool...(installed by snap-pac and snapper-gui-git as well)
 
 #...KDE...
+#'qt5-virtualkeyboard' # Virtual keyboard for login screen (surface devices)
 'konsole' # KDE terminal
 'kate' # KDE text editor
+	'kompare' # File comparison tool (also supports meld) (also supports kdiff3)
+	'meld'
+	'kdiff3'
 'ark' # KDE file archive tool
 	'p7zip'      # 7Z format support 
 	'unrar'      # RAR decompression support
@@ -85,7 +96,7 @@ PKGS_ARCH=(
 'lutris' # gaming platform
 'okular' # pdf viewer
 'qemu' # a hypervisor (virtual machines)
-'steam'
+'steam' # games
 'gamemode' # gaming optimizations
 'synergy' # share kebyard and mouse amung systems
 'virt-manager' # another hypervisor (create virtual machines)
@@ -122,8 +133,8 @@ PKGS_ARCH=(
 'fuseiso' # mount ISO images
 
 #...SAMBA-WINDOWS NETWORK SHARE SUPPORT...
-'samba'
-'smbnetfs'
+#'samba'
+#'smbnetfs'
 
 #...UNNEEDED to explicitly install...
 'unzip' # file compression installed by other things when needed as a dependency

--- a/install.example.conf
+++ b/install.example.conf
@@ -1,4 +1,154 @@
 disk=/dev/sda
-hostname=host
 username=titus
 password=1234
+hostname=host
+
+PKGS_AUR_DEFAULT=(
+'brave-bin' # Brave Browser
+'dxvk-bin' # DXVK DirectX to Vulcan
+'github-desktop-bin' # Github Desktop sync
+'mangohud' # Gaming FPS Counter
+'mangohud-common' #installs with mangohud
+'zoom' # video conferences
+'snap-pac' # btrfs tools...runs snapshot after every pacman install
+'snapper-gui-git' # a tool of managing snapshots of Btrfs subvolumes and LVM volumes
+)
+
+PKGS_ARCH_DEFAULT=(
+
+#...THEME...
+'terminus-font'
+'powerline-fonts'
+
+#...TOOLS...
+'usbutils' # query connected USB devices
+'ntp' # network time protocol reference implementation
+
+#...NETWORK TOOLS...
+'bridge-utils' # configuring etnernet bridge
+'iptables-nft' # replaces iptables
+'traceroute' # track route taken by packets over an IP network
+'openbsd-netcat' # tcp/ip network tools
+'bind' # DNS tools
+'gufw' # manage netfilter firewall
+
+#...MAIN TOOLS...
+'cmatrix' # matix screen
+'cronie' # schedule tasks/jobs
+'htop' # see running processes
+'lsof' # list open files for running Unix processes
+'nano' # a famous text editor
+'neofetch' # displays information about your computer
+'openssh' # remote login another system with the SSH protocol
+'os-prober' # detect other OSes on a set of drives (for grub)
+'vim' # a famous text editor
+'wget' # get files from web
+'git' # get files from web, think github or gitlab
+'bash-completion' # programmable completion for the bash shell
+'zsh' # command line interpreter
+	'zsh-syntax-highlighting'
+	'zsh-autosuggestions'
+	'zsh-completions'
+'pacman-contrib' # scripts and tools for pacman systems
+'rsync' # sync files
+'reflector' # sort and filter pacman mirror list
+'snapper' # managing BTRFS and LVM snapshots tool...also installed by snap-pac and snapper-gui-git
+	      # btrfs can't create snapshots of a volume that also contains a swapfile. I fixed this by moving my swapfile to its own subvolume.
+
+#...KDE...
+'konsole' # KDE terminal
+'kate' # KDE text editor
+'ark' # KDE file archive tool
+	'p7zip'      # 7Z format support 
+	'unrar'      # RAR decompression support
+	'unarchiver' # RAR format support
+	'lzop'       # LZO format support
+	'lrzip'      # LRZ format support
+'gwenview' # KDE image viewer
+	'qt5-imageformats' # tiff, webp and more formats
+	'kimageformats'	   # dds, xcf, exr, psd, and more formats
+	'kipi-plugins'     # export to various online services
+	'kamera'           # imports from gphoto2 cameras
+'filelight' # KDE tool to view disk use
+'spectacle' # KDE screenshot capture utility
+	'kipi-plugins' # export to various online services
+
+#...MISC/OTHER...
+'picom' # X compositor that may fix tearing issues
+'gparted' # graphical partition management
+'grub-customizer' # gui to customize grub
+'kitty' # terminal
+'celluloid' # video players
+'code' # Visual Studio code
+'gimp' # Photo editing
+'jdk-openjdk' # Java 17
+'lutris' # gaming platform
+'okular' # pdf viewer
+'qemu' # a hypervisor (virtual machines)
+'steam'
+'gamemode' # gaming optimizations
+'synergy' # share kebyard and mouse amung systems
+'virt-manager' # another hypervisor (create virtual machines)
+'virt-viewer' # another hypervisor (view virtual machines)
+'wine-gecko' # Wine's built-in replacement for Microsoft's Internet Explorer...(also installs wine)
+'wine-mono' # Wine's built-in replacement for Microsoft's .NET Framework...(also installs wine)
+'winetricks' # makes wine better...(also installs wine)
+
+#...AUDIO/SOUND SUPPORT...
+'alsa-plugins' #(installed by steam)
+'alsa-utils'
+'pulseaudio' #(installed as part of plasma-pa)
+'pulseaudio-alsa'
+'pulseaudio-bluetooth'
+
+#...POWER/BATTERY/SUSPEND SUPPORT...
+'powerdevil' # KDE tool to manage power consumption...(installed as part of plasma-desktop)
+
+#...BLUETOOTH SUPPORT...
+'bluedevil'
+'bluez' # bluetooth support...(installed as part of bluedevil and powerdevil)
+'bluez-libs'  #(installed as part of networkmanager)
+'bluez-utils'
+
+#...PRINTER SUPPORT...
+'cups' # printer support
+'print-manager' # KDE tool to manage printers
+
+#...FILESYSTEM SUPPORT...
+'ntfs-3g' # NTFS support
+'dosfstools' #(installed by kde things)
+'exfat-utils' # exfat support
+'btrfs-progs' #(installed by snap-pac and snapper-gui-git MIGHT MIGHT Be installed by kde things)
+'fuseiso' # mount ISO images
+
+#...SAMBA-WINDOWS NETWORK SHARE SUPPORT...
+'samba'
+'smbnetfs'
+
+#...UNNEEDED to explicitly install...
+'unzip' # file compression installed by other things when needed as a dependency
+'zip' # file compression
+'audiocd-kio' # Audio CDs
+'swtpm' # small tpm emulator
+'dialog' # Shows a dialog by command line
+'dtc'  # Device Tree Compilier (required for qemu and spike a ISA emulator)
+'egl-wayland' # graphics/nvidia
+'extra-cmake-modules' # installs by others things when needed as a dependency
+'fuse2'  #(installed as part of fuseiso)
+'fuse3'  #(installed as part of plasma-worksapce)
+'gptfdisk' #DOES CFDISK work without it? YES  (installed as part of a bunch of kde things)
+'kcoreaddons' #(installed as part of a bunch of kde things)
+'zeroconf-ioslave' # network Monitor for DNS-SD services for KDE
+'kvantum-qt5' 
+'linux-firmware'
+'linux-headers'
+'python-notify2'
+'python-psutil'
+'python-pyqt5'
+#CODECS
+'gst-libav' #installed as part of wine dxvk-bin I DID NOT INSTALL WINE..its DXVK-BIN
+'gst-plugins-good'  #(installed by virt)
+'gst-plugins-ugly'
+'libdvdcss' # Portable abstraction library for DVD decryption
+'kcodecs' #(installed as part of a bunch of kde things)
+)

--- a/makeconf.sh
+++ b/makeconf.sh
@@ -130,7 +130,11 @@ echo "" >> $configFileName
 #	    echo "INSTALLING AUR DEFAULT PACKAGE: ${PKG}"
 #		yay -S --noconfirm $PKG
 #	    echo "${PKG}"
-        echo "${PKG}" >> $configFileName
+	if [ "${PKG}" == "PKGS_AUR_DEFAULT=(" ]; then
+		echo "PKGS_AUR=("
+	else
+        	echo "${PKG}" >> $configFileName
+	fi
 	done
 #else
 #	echo "installing AUR user specified packages"
@@ -155,7 +159,11 @@ echo "" >> $configFileName
 	for PKG in "${PKGS_ARCH_DEFAULT[@]}"; do
 #	    echo "INSTALLING ARCH DEFAULT PACKAGE: ${PKG}"
 #	    pacman -S "$PKG" --noconfirm --needed
-        echo "${PKG}" >> $configFileName
+        if [ "${PKG}" == "PKGS_ARCH_DEFAULT=(" ]; then
+		echo "PKGS_ARCH=("
+	else
+        	echo "${PKG}" >> $configFileName
+	fi
 	done
 #else
 #	echo "installing arch user specified packages"

--- a/makeconf.sh
+++ b/makeconf.sh
@@ -84,6 +84,16 @@ fi
 
 
 
+echo "" >> $configFileName
+echo "# Configuring this section enables showing weather on the taskbar" >> $configFileName
+echo "# and forecasts on the calendar" >> $configFileName
+echo "# Go to 'https://openweathermap.org/find' to get your City ID and Alias" >> $configFileName
+echo "# This example is for Chicago." >> $configFileName
+echo "#openWeatherMapCityId=4887398" >> $configFileName
+echo "#openWeatherMapCityAlias=\"Chicago, US\"" >> $configFileName
+
+
+
 
 # Read default packages from scrips into array...
 # This section of code is not lifted from any other scrips in this repo...custom for this need.

--- a/makeconf.sh
+++ b/makeconf.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Read config file, error if it exists
+#configFileName=${HOME}/ArchTitus/install.conf
+configFileName=$SCRIPT_DIR/install.conf
+if [ -e "$configFileName" ]; then
+	echo "Configuration file install.conf already exists...  Cannot continue."
+    exit
+fi
+
+
+
+echo -e "-------------------------------------------------------------------------"
+echo -e "   █████╗ ██████╗  ██████╗██╗  ██╗████████╗██╗████████╗██╗   ██╗███████╗"
+echo -e "  ██╔══██╗██╔══██╗██╔════╝██║  ██║╚══██╔══╝██║╚══██╔══╝██║   ██║██╔════╝"
+echo -e "  ███████║██████╔╝██║     ███████║   ██║   ██║   ██║   ██║   ██║███████╗"
+echo -e "  ██╔══██║██╔══██╗██║     ██╔══██║   ██║   ██║   ██║   ██║   ██║╚════██║"
+echo -e "  ██║  ██║██║  ██║╚██████╗██║  ██║   ██║   ██║   ██║   ╚██████╔╝███████║"
+echo -e "  ╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝   ╚═╝   ╚═╝   ╚═╝    ╚═════╝ ╚══════╝"
+
+
+
+
+    echo -e "-------------------------------------------------------------------------"
+    echo -e " This script will make a sample config file (install.conf) you can edit  "
+    echo -e " It will ask for disk to format, username, password, and host as well as "
+    echo -e " provide default package list for Arch and ARU you can modify.           "
+    echo -e "-------------------------------------------------------------------------"
+    echo ""
+    lsblk
+    echo ""
+    echo "Above drive breakdown is from THIS MACHINE you are running this make config "
+    echo "script on and MIGHT NOT BE THE SAME AS THE MACHINE YOU INTEND TO INSTALL TO "
+    echo "Be Careful!"
+    echo ""
+    echo "Please enter disk to format: (example /dev/sda)"
+    read disk
+    disk="${disk,,}"
+    if [[ "${disk}" != *"/dev/"* ]]; then
+        disk="/dev/${disk}"
+    fi
+    echo "disk=$disk" >> $configFileName
+
+
+
+
+# Get username
+if [ -e "$configFileName" ] && [ ! -z "$username" ]; then
+	echo "Creating user - $username."
+else
+	read -p "Please enter username:" username
+	echo "username=$username" >> $configFileName
+fi
+
+
+
+
+#    if [ "$password" == "*!*CHANGEME*!*...and-dont-store-in-plantext..." ]; then
+        while true; do
+            read -s -p "Password for $username: " password
+            echo
+            read -s -p "Password for $username (again): " password2
+            echo
+	    if [ "$password" = "$password2" ] && [ "$password" != "" ]; then
+	    	break
+	    fi
+	    echo "Please try again"
+	done
+#	sed -i.bak "s/^\(password=\).*/\1$password/" $configFileName
+    echo "password=$password" >> $configFileName
+
+
+
+
+# Set hostname
+if [ -e "$configFileName" ] && [ ! -z "$hostname" ]; then
+	echo "hostname: $hostname"
+else
+	read -p "Please name your machine:" hostname
+	echo "hostname=$hostname" >> $configFileName
+fi
+#echo $hostname > /etc/hostname
+
+
+
+
+# Read default packages from scrips into array...
+# This section of code is not lifted from any other scrips in this repo...custom for this need.
+PKGS_ARCH_DEFAULT=()
+bolReadLine=false
+while IFS= read -r line; do
+    if [ "$line" == "PKGS_ARCH_DEFAULT=(" ]; then
+        bolReadLine=true
+    fi
+    if [ "$line" == ")" ]; then
+        bolReadLine=false
+    fi
+    if [ $bolReadLine == true ]; then
+        PKGS_ARCH_DEFAULT+=("$line")
+    fi
+done < 1-setup.sh
+
+PKGS_AUR_DEFAULT=()
+bolReadLine=false
+while IFS= read -r line; do
+    if [ "$line" == "PKGS_AUR_DEFAULT=(" ]; then
+        bolReadLine=true
+    fi
+    if [ "$line" == ")" ]; then
+        bolReadLine=false
+    fi
+    if [ $bolReadLine == true ]; then
+        PKGS_AUR_DEFAULT+=("$line")
+    fi
+done < 2-user.sh
+
+
+
+
+echo "" >> $configFileName
+
+
+
+
+## install default or user specified packages (if they exist)
+#if [ ${#PKGS_AUR[@]} -eq 0 ]; then
+#	echo "installing AUR default packages"
+	for PKG in "${PKGS_AUR_DEFAULT[@]}"; do
+#	    echo "INSTALLING AUR DEFAULT PACKAGE: ${PKG}"
+#		yay -S --noconfirm $PKG
+#	    echo "${PKG}"
+        echo "${PKG}" >> $configFileName
+	done
+#else
+#	echo "installing AUR user specified packages"
+#	for PKG in "${PKGS_AUR[@]}"; do
+#	    echo "INSTALLING AUR USER SPECIFIED PACKAGE: ${PKG}"
+#		yay -S --noconfirm $PKG
+#	done
+#fi
+
+
+
+
+echo ")" >> $configFileName
+echo "" >> $configFileName
+
+
+
+
+## install default or user specified packages (if they exist)
+#if [ ${#PKGS_ARCH[@]} -eq 0 ]; then
+#	echo "installing arch default packages"
+	for PKG in "${PKGS_ARCH_DEFAULT[@]}"; do
+#	    echo "INSTALLING ARCH DEFAULT PACKAGE: ${PKG}"
+#	    pacman -S "$PKG" --noconfirm --needed
+        echo "${PKG}" >> $configFileName
+	done
+#else
+#	echo "installing arch user specified packages"
+#	for PKG in "${PKGS_ARCH[@]}"; do
+#	    echo "INSTALLING ARCH USER SPECIFIED PACKAGE: ${PKG}"
+#	    pacman -S "$PKG" --noconfirm --needed
+#	done
+#fi
+
+
+
+echo ")" >> $configFileName
+
+
+
+echo "-------------------------------------------------------------------------"
+echo "--              install.conf for $username generated"
+echo "-------------------------------------------------------------------------"

--- a/makeconf.sh
+++ b/makeconf.sh
@@ -131,7 +131,7 @@ echo "" >> $configFileName
 #		yay -S --noconfirm $PKG
 #	    echo "${PKG}"
 	if [ "${PKG}" == "PKGS_AUR_DEFAULT=(" ]; then
-		echo "PKGS_AUR=("
+		echo "PKGS_AUR=(" >> $configFileName
 	else
         	echo "${PKG}" >> $configFileName
 	fi
@@ -160,7 +160,7 @@ echo "" >> $configFileName
 #	    echo "INSTALLING ARCH DEFAULT PACKAGE: ${PKG}"
 #	    pacman -S "$PKG" --noconfirm --needed
         if [ "${PKG}" == "PKGS_ARCH_DEFAULT=(" ]; then
-		echo "PKGS_ARCH=("
+		echo "PKGS_ARCH=(" >> $configFileName
 	else
         	echo "${PKG}" >> $configFileName
 	fi

--- a/x-bootloader.sh
+++ b/x-bootloader.sh
@@ -12,7 +12,7 @@ if ! grep -qs '/boot ' /proc/mounts; then
         umount -fl /mnt
     	~/ArchTitus/x-mount.sh
 	arch-chroot /mnt /root/ArchTitus/x-bootloader.sh
-	echo "Done.  Please reboot and/or try again if needed".
+	echo "Done.  Please reboot to see if it works now.".
 	exit
 fi
 
@@ -50,9 +50,9 @@ else
 	echo "$grubfile doesn't exist or is empty.  Is grub downloading correctly?".
 	echo "Sometimes file wont exist, or a grub.new file is presnet in /boot/grub"
 	echo "Other times the file will be blank and grub-mkconfig outputs nothing..."
-	echo "Try again or break the script here and investigate"
-	echo "you'll find the following commands useful to investigate"
+	echo "Try installing Arch again or break the script here and investigate"
+	echo "You'll find the following commands useful to investigate..."
 	echo "arch-chroot /mnt"
 	echo "grub-mkconfig -o $grubfile"
-	read -n 1 -s -r -p "Press any key to continue...or manually break script here."
+	read -n 1 -s -r -p "Your system will not boot.  Press any key to continue...or manually break script here."
 fi

--- a/x-bootloader.sh
+++ b/x-bootloader.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Read config file, if it exists
+configFileName=${HOME}/ArchTitus/install.conf
+if [ -e "$configFileName" ]; then
+	echo "Using configuration file $configFileName."
+	. $configFileName
+fi
+
+# Check partitions are mounted
+if ! grep -qs '/boot ' /proc/mounts; then
+        umount -fl /mnt
+    	~/ArchTitus/x-mount.sh
+	arch-chroot /mnt /root/ArchTitus/x-bootloader.sh
+	echo "Done.  Please reboot and/or try again if needed".
+	exit
+fi
+
+# install grub
+if [[ ! -d "/sys/firmware/efi" ]]; then
+	pacman -S grub --noconfirm --needed
+	echo "Detected BIOS..."
+	if [ -z "$disk" ]; then
+		lsblk
+		echo "Please enter disk to install bootloader to: (example /dev/sda)"
+		read disk
+		disk="${disk,,}"
+		if [[ "${disk}" != *"/dev/"* ]]; then
+			disk="/dev/${disk}"
+		fi
+	else
+		echo "Installing BIOS GRUB to $disk."
+	fi
+	grub-install --boot-directory=/boot $disk
+fi
+if [[ -d "/sys/firmware/efi" ]]; then
+    pacman -S grub efibootmgr --noconfirm --needed
+    echo "Detected EFI..."
+    grub-install --efi-directory=/boot
+fi
+
+grubfile=/boot/grub/grub.cfg
+grub-mkconfig -o $grubfile
+
+if [[ -s $grubfile ]]; then
+	cat $grubfile
+   	echo "$grubfile exists and not empty"
+	read -n 1 -s -r -p "Press any key to continue...or manually break script here."
+else
+	echo ""
+	echo "$grubfile doesn't exist or is empty.  Is grub downloading correctly?".
+	echo "Sometimes file wont exist, or a grub.new file is presnet in /boot/grub"
+	echo "Other times the file will be blank and grub-mkconfig outputs nothing..."
+	echo "Try again or break the script here and investigate"
+	echo "you'll find the following commands useful to investigate"
+	echo "arch-chroot /mnt"
+	echo "grub-mkconfig -o $grubfile"
+	read -n 1 -s -r -p "Press any key to continue...or manually break script here."
+fi

--- a/x-bootloader.sh
+++ b/x-bootloader.sh
@@ -44,8 +44,7 @@ grub-mkconfig -o $grubfile
 
 if [[ -s $grubfile ]]; then
 	cat $grubfile
-   	echo "$grubfile exists and not empty"
-	read -n 1 -s -r -p "Press any key to continue...or manually break script here."
+   	echo "$grubfile exists (and not empty?)"
 else
 	echo ""
 	echo "$grubfile doesn't exist or is empty.  Is grub downloading correctly?".

--- a/x-mount.sh
+++ b/x-mount.sh
@@ -8,7 +8,7 @@
     mount -t vfat -L BOOT /mnt/boot
 
     if ! grep -qs '/mnt' /proc/mounts; then
-        echo "Drive did not mount correctly.  Can not continue!"
+        echo "Drive did not mount correctly.  Cannot continue!"
         read -n 1 -s -r -p "Press any key to reboot..."
         reboot now
     fi

--- a/x-mount.sh
+++ b/x-mount.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+    # mount target
+    echo "Mounting Filesystems..."
+    mount -t btrfs -o subvol=@ -L ROOT /mnt
+    mkdir /mnt/boot
+    mkdir /mnt/boot/efi
+    mount -t vfat -L BOOT /mnt/boot
+
+    if ! grep -qs '/mnt' /proc/mounts; then
+        echo "Drive did not mount correctly.  Can not continue!"
+        read -n 1 -s -r -p "Press any key to reboot..."
+        reboot now
+    fi


### PR DESCRIPTION
I support some on 50 machines, this script was a perfect template.  I kept all the same functionality but added the ability to customize with install.conf.  It was based on an old pull.  I see there were a few new changes that might not be compatible with this one directly (pulling packages form package files in the folder, for example)

Maybe chris can create a new branch for this one and we can merge changes into it (username lowercase..for example)?  

**Summary of changes...**

Expanded install.conf ... stores and reads variables for use during install process (password is masked)
Expanded install.conf ... non-core packages can be defined there, but originals default if nothing is specified
	Separated packages into five groups.  
	Allowing user to have an optional config file to install packages of their choice
		1) AUR Core (packages that make it what it is...eg themes and fonts)
		2) AUR Default (that Chris Titus likes and uses...eg steam)
		3) AUR User Specified (allows user to override replacing some packages with others 
				eg remove steam but, add spotify)
		4) Arch Default (that Chris Titus likes and uses...eg celluloid, gimp)
		5) Arch User Specified (allows user to override replacing some packages with others
				eg remove celluloid, add vlc)
Expanded install.conf ... can optionally specify a city ID and install weather applets
Improved grub install accuracy, it was flaky sometetimes...and still is!!
Added hypervisor tools detection
Added hosts file
Added dynamic timezone (curl -s -4 http://ip-api.com/line?fields=timezone)
Added dynamic timezone on NetworkManager up (can be removed by deleting a file)
Added ability to re-install grub with script (x-bootloader.sh)
Added ability to specify sda instead of /dev/sda when formatting
Saying no to format request ends script gracefully
Some little things I forgot?


**Questions:**
	Why does grub sometimes fail?  It's flakey.  Most of the time it works, sometimes grub-mkconfig has no output.
	How can we install to a swap partition instead of swapfile for btrfs snapshots?


**Added Packages to default:** 
	Chris, if you're like...NOPE dont want them on my system...Can be removed from default
_Unconfigurable in options..._
		packagekit-qt5					needed for discover, which is in the plasma group
		kdialog							needed for some apps to display native kde dialogs
		ffmpegthumbs					need for video thumbnails in dolphin (easily turnd off in settings)

_Configurable in optional file..._
		zsh-completions					
		gufw							gui upgrade (for ufw)
		unarchiver						RAR format support (+ unrar still included) (for ark)
		lrzip							        LRZ format support (for ark)
		qt5-imageformats 				        tiff, webp and more formats  (for gwenview)
		kimageformats	   				dds, xcf, exr, psd, and more formats  (for gwenview)
		kipi-plugins     				        export to various online services  (for gwenview)
		kamera           				                imports from gphoto2 cameras (for gwenview)
		samba							#Commented out
		smbnetfs						        #Commented out
		qt5-virtualkeyboard				#Commented out Virtual keyboard for login screen.
		dmidecode
		kompare							As options for kate file compare
		meld							As options for kate file compare
		kdiff3							As options for kate file compare


**Arch Packages (pacstrap /mnt)**
	base								        retained
	base-devel							moved to user install section
	linux								retained
	linux-firmware						        moved to package install section
	vim									moved to package install section
	nano								moved to package install section
	sudo								retained
	archlinux-keyring					        removed required by pacman in base
	wget								moved to package install section
	libnewt								removed but really moved to package install section required by networkmanager


**chroot packages**
	*Network Setup Section*
	networkmanager						moved to pacscrap so system functions, iwd added to pacstrap too.
	dhclient							        REMOVED not needed with networkmanager
												systemctl enable --now NetworkManager

	**Optimal Download Section**
	pacman-contrib						moved to package install section
	curl								        removed required by pacman in base
	reflector							        moved to package install section...copied file from iso run
	rsync								moved to package install section...copied file from iso run



**PKGS=(**
	'mesa' # Essential Xorg First		       REMOVED dependency for lots of things
	'xorg'						       retained 
	'xorg-server'						removed, in xorg group			
	'xorg-apps'						removed, in xorg group
	'xorg-drivers'						removed, in xorg group'xorg-xkill'						REMOVED not needed but installs from xorg group
	'xorg-xinit'						REMOVED not needed
	'xterm							REMOVED not needed
	'plasma-desktop' # KDE Load second	removed, in plasma group
	'alsa-plugins' # audio plugins		        retained
	'alsa-utils' # audio utils			        retained
	'ark' # compression					retained
	'audiocd-kio' 						retained, but thinking uneeded
	'autoconf' # build					removed, in base-devel group
	'automake' # build					removed, in base-devel group
	'base'							moved to pacstrap section
	'bash-completion'					retained
	'bind'							retained
	'binutils'							removed, in base-devel group
	'bison'							removed, in base-devel group
	'bluedevil'						retained, also in plasma group
	'bluez'							retained
	'bluez-libs'						retained
	'bluez-utils'						retained
	'breeze'							removed, in plasma group
	'breeze-gtk'						removed, in plasma group
	'bridge-utils'						retained
	'btrfs-progs'						retained
	'celluloid' # video players			retained
	'cmatrix'							retained
	'code' # Visual Studio code			retained
	'cronie'							retained
	'cups'							retained
	'dialog'							retained, but thinking uneeded
	'discover'							removed, in plasma group
	'dolphin'							retained
	'dosfstools'						retained
	'dtc'								retained, but thinking uneeded -- installed by qemu
	'efibootmgr' # EFI boot				moved to new boot config section
	'egl-wayland'						retained, but thinking uneeded
	'exfat-utils'						retained
	'extra-cmake-modules'				retained, but thinking uneeded -- installed as build dependency
	'filelight'							retained
	'flex'								removed, in base-devel group
	'fuse2'							retained, but thinking uneeded -- dependency
	'fuse3'							retained, but thinking uneeded -- dependency
	'fuseiso'							retained
	'gamemode'						retained
	'gcc'								removed, in base-devel group
	'gimp' # Photo editing				retained
	'git'								retained, dependency for lots of things
	'gparted' # partition management	        retained
	'gptfdisk'							retained, but thinking uneeded, CFDISK works without it -- dependency
	'grub'							moved to new boot config section
	'grub-customizer'					retained
	'gst-libav'						retained, but thinking uneeded -- dependency (wine + dxvk-bin)
	'gst-plugins-good'					retained, but thinking uneeded -- dependency (virt)
	'gst-plugins-ugly'					retained, but thinking uneeded
	'gwenview'						retained
	'haveged'							REMOVED, obsolete from Linux kernel v5.6
	'htop'							retained
	'iptables-nft'						retained
	'jdk-openjdk' # Java 17				retained
	'kate'							retained
	'kcodecs'							retained, but thinking uneeded -- dependency
	'kcoreaddons'						retained, but thinking uneeded -- dependency
	'kdeplasma-addons'				removed, required by plasma group
	'kde-gtk-config'					removed, required by plasma group
	'kinfocenter'						removed, in plasma group
	'kscreen'							removed, in plasma group -- duplicated
	'kvantum-qt5'						retained, but thinking uneeded
	'kitty'							retained
	'konsole'							retained
	'kscreen'							removed, in plasma group -- duplicated
	'layer-shell-qt'					        removed, in plasma group, required by kscreenlocker
	'libdvdcss'						retained, but thinking uneeded
	'libnewt'							removed, in plasma group, required by networkmanager
	'libtool'							removed, in base-devel group
	'linux'							moved to pacstrap section
	'linux-firmware'					retained, but thinking uneeded
	'linux-headers'						retained, but thinking uneeded
	'lsof'								retained
	'lutris'							retained
	'lzop'							retained
	'm4'								removed, in base-devel group
	'make'							removed, in base-devel group
	'milou'							removed, in plasma group, required by plasma-workspace
	'nano'							retained
	'neofetch'						retained
	'networkmanager'					moved to pacastrap section
	'ntfs-3g'							retained
	'ntp'								retained
	'okular'							retained
	'openbsd-netcat'					retained
	'openssh'							retained
	'os-prober'						retained
	'oxygen'							removed, in plasma group
	'p7zip'							retained
	'pacman-contrib'					retained
	'patch'							removed, in base-devel group
	'picom'							retained
	'pkgconf'							removed, in base-devel group
	'plasma-meta'						REMOVED, replaced with plasma group
	'plasma-nm'						removed, in plasma group
	'powerdevil'						retained
	'powerline-fonts'					retained
	'print-manager'					retained
	'pulseaudio'						retained
	'pulseaudio-alsa'					retained
	'pulseaudio-bluetooth'				retained
	'python-notify2'					retained, but thinking uneeded
	'python-psutil'						retained, but thinking uneeded
	'python-pyqt5'					retained, but thinking uneeded
	'python-pip'						moved to user install section (for konsave)
	'qemu'							retained
	'rsync'							retained
	'sddm'							removed, in plasma group
	'sddm-kcm'						removed, in plasma group
	'snapper'							retained
	'spectacle'						retained
	'steam'							retained
	'sudo'							removed, in pacastrap and base-devel group	
	'swtpm'							retained, but thinking uneeded
	'synergy'							retained
	'systemsettings'					removed, in plasma group
	'terminus-font'					retained
	'traceroute'						retained
	'ufw'							retained -- UPGRADED to gufw
	'unrar'							retained
	'unzip'							retained, but thinking uneeded -- installed by other things when needed as a depenency
	'usbutils'							retained
	'vim'								retained
	'virt-manager'
	'virt-viewer'
	'wget'							retained
	'which'							removed, in base-devel group
	'wine-gecko'
	'wine-mono'
	'winetricks'
	'xdg-desktop-portal-kde'			removed, required by plasma group
	'xdg-user-dirs'						removed, in plasma group, required by plasma-desktop
	'zeroconf-ioslave'					retained, but thinking uneeded
	'zip'								retained, but thinking uneeded
	'zsh'								retained
	'zsh-syntax-highlighting'			retained
	'zsh-autosuggestions'				retained
)
	

**PKGS=(**
	'autojump'							retained
	'awesome-terminal-fonts'				retained
	'brave-bin' # Brave Browser				retained
	'dxvk-bin' # DXVK DirectX to Vulcan		retained
	'github-desktop-bin' # Github sync		retained
	'lightly-git'							retained
	'lightlyshaders-git'					        retained (problems installing...)
	'mangohud' # Gaming FPS Counter		retained
	'mangohud-common'					retained (also installs with mangohud)
	'nerd-fonts-fira-code'					retained
	'nordic-darker-standard-buttons-theme'	retained
	'nordic-darker-theme'					retained
	'nordic-kde-git'						retained
	'nordic-theme'						retained
	'noto-fonts-emoji'						retained
	'papirus-icon-theme'					retained
	'plasma-pa'							retained (why from AUR??)
	'ocs-url' # install packages from web	        retained
	'sddm-nordic-theme-git'				retained
	'snapper-gui-git'						retained
	'ttf-droid'								retained
	'ttf-hack'								retained
	'ttf-meslo' # Nerdfont package			retained
	'ttf-roboto'							retained
	'zoom' # video conferences				retained
	'snap-pac'							retained
)