### PR TITLE
Fix/nvme drive

### DIFF
--- a/0-preinstall.sh
+++ b/0-preinstall.sh
@@ -91,7 +91,7 @@ if [[ "${DISK}" =~ "nvme" ]]; then
     elif [[ "${FS}" == "luks" ]]; then
         mkfs.vfat -F32 -n "EFIBOOT" ${DISK}p2
 # enter luks password to cryptsetup and format root partition
-        echo -n "${luks_password}" | cryptsetup -y -v luksFormat ${DISK}p3 -
+        echo -n "${luks_password}" | cryptsetup -v luksFormat ${DISK}p3 -
 # open luks container and ROOT will be place holder 
         echo -n "${luks_password}" | cryptsetup open ${DISK}p3 ROOT -
 # now format that container

--- a/0-preinstall.sh
+++ b/0-preinstall.sh
@@ -79,7 +79,7 @@ mountallsubvol () {
     mount -o noatime,compress=zstd,space_cache,commit=120,subvol=@.snapshots /dev/mapper/ROOT /mnt/.snapshots
     mount -o subvol=@var /dev/mapper/ROOT /mnt/var
 }
-if [[ "${DISK}" == "nvme" ]]; then
+if [[ "${DISK}" =~ "nvme" ]]; then
     if [[ "${FS}" == "btrfs" ]]; then
         mkfs.vfat -F32 -n "EFIBOOT" ${DISK}p2
         mkfs.btrfs -L ROOT ${DISK}p3 -f

--- a/0-preinstall.sh
+++ b/0-preinstall.sh
@@ -118,7 +118,7 @@ else
         mount -t ext4 ${DISK}3 /mnt
     elif [[ "${FS}" == "luks" ]]; then
         mkfs.vfat -F32 -n "EFIBOOT" ${DISK}2
-        echo -n "${luks_password}" | cryptsetup -y -v luksFormat ${DISK}3 -
+        echo -n "${luks_password}" | cryptsetup -v luksFormat ${DISK}3 -
         echo -n "${luks_password}" | cryptsetup open ${DISK}3 ROOT -
         mkfs.btrfs -L ROOT /dev/mapper/ROOT
         mount -t btrfs /dev/mapper/ROOT /mnt


### PR DESCRIPTION
Hello,
When trying out the luks install, I encountered some errors:

- although I installed on an nvme drive, the script used `nvme0n13` instead of  `nvme0n1p3` as volume labels
- the cryptsetup failed. see: https://forums.gentoo.org/viewtopic-t-712010.html

Here are my fixes for now.
The setup now fails with a BTRFS error I will address later.

Thank you for the amazing script!