### PR TITLE
exfat-utils >> exfatprogs

### DIFF
--- a/1-setup.sh
+++ b/1-setup.sh
@@ -94,7 +94,7 @@ PKGS=(
 'dtc'
 'efibootmgr' # EFI boot
 'egl-wayland'
-'exfat-utils'
+'exfatprogs'
 'extra-cmake-modules'
 'filelight'
 'flex'


### PR DESCRIPTION
exfat-utils no longer work. To mount an exfat drive exfatprogs are needed