### PR TITLE
Update aur-pkgs.txt and pacman-pkgs.txt

### DIFF
--- a/pkg-files/aur-pkgs.txt
+++ b/pkg-files/aur-pkgs.txt
@@ -11,8 +11,6 @@ nordic-darker-standard-buttons-theme
 nordic-darker-theme
 nordic-kde-git
 nordic-theme
-papirus-icon-theme
-plasma-pa
 ocs-url
 sddm-nordic-theme-git
 snapper-gui-git

--- a/pkg-files/aur-pkgs.txt
+++ b/pkg-files/aur-pkgs.txt
@@ -11,7 +11,6 @@ nordic-darker-standard-buttons-theme
 nordic-darker-theme
 nordic-kde-git
 nordic-theme
-noto-fonts-emoji
 papirus-icon-theme
 plasma-pa
 ocs-url

--- a/pkg-files/aur-pkgs.txt
+++ b/pkg-files/aur-pkgs.txt
@@ -14,7 +14,6 @@ nordic-theme
 ocs-url
 sddm-nordic-theme-git
 snapper-gui-git
-ttf-droid
 ttf-hack
 ttf-meslo
 ttf-roboto

--- a/pkg-files/aur-pkgs.txt
+++ b/pkg-files/aur-pkgs.txt
@@ -14,8 +14,5 @@ nordic-theme
 ocs-url
 sddm-nordic-theme-git
 snapper-gui-git
-ttf-hack
 ttf-meslo
-ttf-roboto
 zoom
-snap-pac

--- a/pkg-files/aur-pkgs.txt
+++ b/pkg-files/aur-pkgs.txt
@@ -1,5 +1,4 @@
 autojump
-awesome-terminal-fonts
 brave-bin
 dxvk-bin
 github-desktop-bin

--- a/pkg-files/pacman-pkgs.txt
+++ b/pkg-files/pacman-pkgs.txt
@@ -13,6 +13,7 @@ ark
 audiocd-kio
 autoconf
 automake
+awesome-terminal-fonts
 base
 bash-completion
 bind

--- a/pkg-files/pacman-pkgs.txt
+++ b/pkg-files/pacman-pkgs.txt
@@ -89,6 +89,7 @@ milou
 nano
 neofetch
 networkmanager
+noto-fonts-emoji
 ntfs-3g
 ntp
 okular

--- a/pkg-files/pacman-pkgs.txt
+++ b/pkg-files/pacman-pkgs.txt
@@ -120,6 +120,7 @@ rsync
 sddm
 sddm-kcm
 snapper
+snap-pac
 spectacle
 steam
 sudo
@@ -129,6 +130,8 @@ systemsettings
 terminus-font
 traceroute
 ttf-droid
+ttf-hack
+ttf-roboto
 ufw
 unrar
 unzip

--- a/pkg-files/pacman-pkgs.txt
+++ b/pkg-files/pacman-pkgs.txt
@@ -99,10 +99,12 @@ os-prober
 oxygen
 p7zip
 pacman-contrib
+papirus-icon-theme
 patch
 picom
 pkgconf
 plasma-nm
+plasma-pa
 powerdevil
 powerline-fonts
 print-manager

--- a/pkg-files/pacman-pkgs.txt
+++ b/pkg-files/pacman-pkgs.txt
@@ -128,6 +128,7 @@ synergy
 systemsettings
 terminus-font
 traceroute
+ttf-droid
 ufw
 unrar
 unzip


### PR DESCRIPTION
I removed every package from the 'aur-pkgs.txt'-file that can also be installed with pacman from the standard repositorys and added them in the 'pacman-pkgs.txt'-file.
The moved packages are:
- awesome-terminal-fonts
- noto-fonts-emoji
- papirus-icon-theme
- plasma-pa
- ttf-droid
- ttf-hack
- ttf-roboto
- snap-pac