### PR TITLE
Fix typos and make naming convention consistent

### DIFF
--- a/1-setup.sh
+++ b/1-setup.sh
@@ -29,18 +29,18 @@ pacman -S --noconfirm pacman-contrib curl
 pacman -S --noconfirm reflector rsync
 cp /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak
 
-nc=$(grep -c ^processor /proc/cpuinfo)
+NC=$(grep -c ^processor /proc/cpuinfo)
 echo -ne "
 -------------------------------------------------------------------------
-                    You have " $nc" cores. And
-			changing the makeflags for "$nc" cores. Aswell as
+                    You have " $NC" cores. And
+			changing the makeflags for "$NC" cores. Aswell as
 				changing the compression settings.
 -------------------------------------------------------------------------
 "
-TOTALMEM=$(cat /proc/meminfo | grep -i 'memtotal' | grep -o '[[:digit:]]*')
-if [[  $TOTALMEM -gt 8000000 ]]; then
-sed -i "s/#MAKEFLAGS=\"-j2\"/MAKEFLAGS=\"-j$nc\"/g" /etc/makepkg.conf
-sed -i "s/COMPRESSXZ=(xz -c -z -)/COMPRESSXZ=(xz -c -T $nc -z -)/g" /etc/makepkg.conf
+TOTAL_MEM=$(cat /proc/meminfo | grep -i 'memtotal' | grep -o '[[:digit:]]*')
+if [[  $TOTAL_MEM -gt 8000000 ]]; then
+sed -i "s/#MAKEFLAGS=\"-j2\"/MAKEFLAGS=\"-j$NC\"/g" /etc/makepkg.conf
+sed -i "s/COMPRESSXZ=(xz -c -z -)/COMPRESSXZ=(xz -c -T $NC -z -)/g" /etc/makepkg.conf
 fi
 echo -ne "
 -------------------------------------------------------------------------
@@ -71,10 +71,10 @@ echo -ne "
                     Installing Base System  
 -------------------------------------------------------------------------
 "
-cat /root/ArchTitus/pkg-files/pacman-pkgs.txt | while read line 
+cat /root/ArchTitus/pkg-files/pacman-pkgs.txt | while read LINE 
 do
-    echo "INSTALLING: ${line}"
-   sudo pacman -S --noconfirm --needed ${line}
+    echo "INSTALLING: ${LINE}"
+   sudo pacman -S --noconfirm --needed ${LINE}
 done
 echo -ne "
 -------------------------------------------------------------------------
@@ -82,12 +82,12 @@ echo -ne "
 -------------------------------------------------------------------------
 "
 # determine processor type and install microcode
-proc_type=$(lscpu)
-if grep -E "GenuineIntel" <<< ${proc_type}; then
+PROC_TYPE=$(lscpu)
+if grep -E "GenuineIntel" <<< ${PROC_TYPE}; then
     echo "Installing Intel microcode"
     pacman -S --noconfirm intel-ucode
     proc_ucode=intel-ucode.img
-elif grep -E "AuthenticAMD" <<< ${proc_type}; then
+elif grep -E "AuthenticAMD" <<< ${PROC_TYPE}; then
     echo "Installing AMD microcode"
     pacman -S --noconfirm amd-ucode
     proc_ucode=amd-ucode.img
@@ -99,15 +99,15 @@ echo -ne "
 -------------------------------------------------------------------------
 "
 # Graphics Drivers find and install
-gpu_type=$(lspci)
-if grep -E "NVIDIA|GeForce" <<< ${gpu_type}; then
+GPU_TYPE=$(lspci)
+if grep -E "NVIDIA|GeForce" <<< ${GPU_TYPE}; then
     pacman -S nvidia --noconfirm --needed
 	nvidia-xconfig
 elif lspci | grep 'VGA' | grep -E "Radeon|AMD"; then
     pacman -S xf86-video-amdgpu --noconfirm --needed
-elif grep -E "Integrated Graphics Controller" <<< ${gpu_type}; then
+elif grep -E "Integrated Graphics Controller" <<< ${GPU_TYPE}; then
     pacman -S libva-intel-driver libvdpau-va-gl lib32-vulkan-intel vulkan-intel libva-intel-driver libva-utils lib32-mesa --needed --noconfirm
-elif grep -E "Intel Corporation UHD" <<< ${gpu_type}; then
+elif grep -E "Intel Corporation UHD" <<< ${GPU_TYPE}; then
     pacman -S libva-intel-driver libvdpau-va-gl lib32-vulkan-intel vulkan-intel libva-intel-driver libva-utils lib32-mesa --needed --noconfirm
 fi
 #SETUP IS WRONG THIS IS RUN
@@ -115,28 +115,28 @@ if ! source /root/ArchTitus/setup.conf; then
 	# Loop through user input until the user gives a valid username
 	while true
 	do 
-		read -p "Please enter username:" username
+		read -p "Please enter username:" USERNAME
 		# username regex per response here https://unix.stackexchange.com/questions/157426/what-is-the-regex-to-validate-linux-users
 		# lowercase the username to test regex
-		if [[ "${username,,}" =~ ^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$ ]]
+		if [[ "${USERNAME,,}" =~ ^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$ ]]
 		then 
 			break
 		fi 
 		echo "Incorrect username."
 	done 
 # convert name to lowercase before saving to setup.conf
-echo "username=${username,,}" >> ${HOME}/ArchTitus/setup.conf
+echo "USERNAME=${USERNAME,,}" >> ${HOME}/ArchTitus/setup.conf
 
     #Set Password
-    read -p "Please enter password:" password
-echo "password=${password,,}" >> ${HOME}/ArchTitus/setup.conf
+    read -p "Please enter password:" PASSWORD
+echo "PASSWORD=${PASSWORD,,}" >> ${HOME}/ArchTitus/setup.conf
 
     # Loop through user input until the user gives a valid hostname, but allow the user to force save 
 	while true
 	do 
-		read -p "Please name your machine:" nameofmachine
+		read -p "Please name your machine:" NAME_OF_MACHINE
 		# hostname regex (!!couldn't find spec for computer name!!)
-		if [[ "${nameofmachine,,}" =~ ^[a-z][a-z0-9_.-]{0,62}[a-z0-9]$ ]]
+		if [[ "${NAME_OF_MACHINE,,}" =~ ^[a-z][a-z0-9_.-]{0,62}[a-z0-9]$ ]]
 		then 
 			break 
 		fi 
@@ -148,7 +148,7 @@ echo "password=${password,,}" >> ${HOME}/ArchTitus/setup.conf
 		fi 
 	done 
 
-    echo "nameofmachine=${nameofmachine,,}" >> ${HOME}/ArchTitus/setup.conf
+    echo "NAME_OF_MACHINE=${NAME_OF_MACHINE,,}" >> ${HOME}/ArchTitus/setup.conf
 fi
 echo -ne "
 -------------------------------------------------------------------------
@@ -159,19 +159,19 @@ if [ $(whoami) = "root"  ]; then
     groupadd libvirt
     useradd -m -G wheel,libvirt -s /bin/bash $USERNAME 
 
-# use chpasswd to enter $USERNAME:$password
+# use chpasswd to enter $USERNAME:$PASSWORD
     echo "$USERNAME:$PASSWORD" | chpasswd
 	cp -R /root/ArchTitus /home/$USERNAME/
     chown -R $USERNAME: /home/$USERNAME/ArchTitus
-# enter $nameofmachine to /etc/hostname
-	echo $nameofmachine > /etc/hostname
+# enter $NAME_OF_MACHINE to /etc/hostname
+	echo $NAME_OF_MACHINE > /etc/hostname
 else
 	echo "You are already a user proceed with aur installs"
 fi
 if [[ ${FS} == "luks" ]]; then
 # Making sure to edit mkinitcpio conf if luks is selected
-# add encrypt in mkinitcpio.conf before filesystems in hooks
-    sed -i 's/filesystems/encrypt filesystems/g' /etc/mkinitcpio.conf
+# add eNCrypt in mkinitcpio.conf before filesystems in hooks
+    sed -i 's/filesystems/eNCrypt filesystems/g' /etc/mkinitcpio.conf
 # making mkinitcpio with linux kernel
     mkinitcpio -p linux
 fi

--- a/3-post-setup.sh
+++ b/3-post-setup.sh
@@ -21,7 +21,7 @@ if [[ -d "/sys/firmware/efi" ]]; then
 fi
 # set kernel parameter for decrypting the drive
 if [[ "${FS}" == "luks" ]]; then
-sed -i "s%GRUB_CMDLINE_LINUX_DEFAULT=\"%GRUB_CMDLINE_LINUX_DEFAULT=\"cryptdevice=UUID=${encryped_partition_uuid}:ROOT root=/dev/mapper/ROOT %g" /etc/default/grub
+sed -i "s%GRUB_CMDLINE_LINUX_DEFAULT=\"%GRUB_CMDLINE_LINUX_DEFAULT=\"cryptdevice=UUID=${ENCRYPTED_PARTITION_UUID}:ROOT root=/dev/mapper/ROOT %g" /etc/default/grub
 fi
 
 echo -e "Installing CyberRe Grub theme..."
@@ -83,4 +83,4 @@ rm -r /root/ArchTitus
 rm -r /home/$USERNAME/ArchTitus
 
 # Replace in the same state
-cd $pwd
+cd $PWD

--- a/install.example.conf
+++ b/install.example.conf
@@ -1,3 +1,3 @@
-hostname=host
-username=titus
-password=1234
+HOSTNAME=host
+USERNAME=titus
+PASSWORD=1234

--- a/startup.sh
+++ b/startup.sh
@@ -48,8 +48,8 @@ case $FS in
 2) set_option FS ext4;;
 3) 
 echo -ne "Please enter your luks password: "
-read -s luks_password # read password without echo
-set_option luks_password $luks_password
+read -s LUKS_PASSWORD # read password without echo
+set_option LUKS_PASSWORD $LUKS_PASSWORD
 set_option FS luks;;
 0) exit ;;
 *) echo "Wrong option please select again"; filesystem;;
@@ -57,17 +57,17 @@ esac
 }
 timezone () {
 # Added this from arch wiki https://wiki.archlinux.org/title/System_time
-time_zone="$(curl --fail https://ipapi.co/timezone)"
-echo -ne "System detected your timezone to be '$time_zone' \n"
+TIME_ZONE="$(curl --fail https://ipapi.co/timezone)"
+echo -ne "System detected your timezone to be '$TIME_ZONE' \n"
 echo -ne "Is this correct? yes/no:" 
 read answer
 case $answer in
     y|Y|yes|Yes|YES)
-    set_option TIMEZONE $time_zone;;
+    set_option TIMEZONE $TIME_ZONE;;
     n|N|no|NO|No)
     echo "Please enter your desired timezone e.g. Europe/London :" 
-    read new_timezone
-    set_option TIMEZONE $new_timezone;;
+    read NEW_TIMEZONE
+    set_option TIMEZONE $NEW_TIMEZONE;;
     *) echo "Wrong option. Try again";timezone;;
 esac
 }
@@ -104,21 +104,21 @@ Please select key board layout from this list
     -us
 
 "
-read -p "Your key boards layout:" keymap
-set_option KEYMAP $keymap
+read -p "Your key boards layout:" KEYMAP
+set_option KEYMAP $KEYMAP
 }
 
 drivessd () {
 echo -ne "
 Is this an ssd? yes/no:
 "
-read ssd_drive
+read SSD_DRIVE
 
-case $ssd_drive in
+case $SSD_DRIVE in
     y|Y|yes|Yes|YES)
-    echo "mountoptions=noatime,compress=zstd,ssd,commit=120" >> setup.conf;;
+    echo "MOUNT_OPTIONS=noatime,compress=zstd,ssd,commit=120" >> setup.conf;;
     n|N|no|NO|No)
-    echo "mountoptions=noatime,compress=zstd,commit=120" >> setup.conf;;
+    echo "MOUNT_OPTIONS=noatime,compress=zstd,commit=120" >> setup.conf;;
     *) echo "Wrong option. Try again";drivessd;;
 esac
 }
@@ -136,20 +136,20 @@ echo -ne "
 
 Please enter full path to disk: (example /dev/sda):
 "
-read option
-echo "DISK=$option" >> setup.conf
+read OPTION
+echo "DISK=$OPTION" >> setup.conf
 
 drivessd
-set_option DISK $option
+set_option DISK $OPTION
 }
 userinfo () {
-read -p "Please enter your username: " username
-set_option USERNAME ${username,,} # convert to lower case as in issue #109 
+read -p "Please enter your username: " USERNAME
+set_option USERNAME ${USERNAME,,} # convert to lower case as in issue #109 
 echo -ne "Please enter your password: \n"
-read -s password # read password without echo
-set_option PASSWORD $password
-read -rep "Please enter your hostname: " nameofmachine
-set_option nameofmachine $nameofmachine
+read -s PASSWORD # read password without echo
+set_option PASSWORD $PASSWORD
+read -rep "Please enter your hostname: " NAME_OF_MACHINE
+set_option NAME_OF_MACHINE $NAME_OF_MACHINE
 }
 # More features in future
 # language (){}


### PR DESCRIPTION
Issue that occurred with the username recently made me want to make sure all the variables followed the same naming convention to prevent an issue like that being hard to spot or occur again if people follow the existing standard. 