### PR TITLE
Fix typos and make naming convention consistent

### DIFF
--- a/1-setup.sh
+++ b/1-setup.sh
@@ -37,8 +37,8 @@ echo -ne "
 				changing the compression settings.
 -------------------------------------------------------------------------
 "
-TOTALMEM=$(cat /proc/meminfo | grep -i 'memtotal' | grep -o '[[:digit:]]*')
-if [[  $TOTALMEM -gt 8000000 ]]; then
+TOTAL_MEM=$(cat /proc/meminfo | grep -i 'memtotal' | grep -o '[[:digit:]]*')
+if [[  $TOTAL_MEM -gt 8000000 ]]; then
 sed -i "s/#MAKEFLAGS=\"-j2\"/MAKEFLAGS=\"-j$nc\"/g" /etc/makepkg.conf
 sed -i "s/COMPRESSXZ=(xz -c -z -)/COMPRESSXZ=(xz -c -T $nc -z -)/g" /etc/makepkg.conf
 fi
@@ -134,9 +134,9 @@ echo "password=${password,,}" >> ${HOME}/ArchTitus/setup.conf
     # Loop through user input until the user gives a valid hostname, but allow the user to force save 
 	while true
 	do 
-		read -p "Please name your machine:" nameofmachine
+		read -p "Please name your machine:" name_of_machine
 		# hostname regex (!!couldn't find spec for computer name!!)
-		if [[ "${nameofmachine,,}" =~ ^[a-z][a-z0-9_.-]{0,62}[a-z0-9]$ ]]
+		if [[ "${name_of_machine,,}" =~ ^[a-z][a-z0-9_.-]{0,62}[a-z0-9]$ ]]
 		then 
 			break 
 		fi 
@@ -148,7 +148,7 @@ echo "password=${password,,}" >> ${HOME}/ArchTitus/setup.conf
 		fi 
 	done 
 
-    echo "nameofmachine=${nameofmachine,,}" >> ${HOME}/ArchTitus/setup.conf
+    echo "NAME_OF_MACHINE=${name_of_machine,,}" >> ${HOME}/ArchTitus/setup.conf
 fi
 echo -ne "
 -------------------------------------------------------------------------
@@ -163,8 +163,8 @@ if [ $(whoami) = "root"  ]; then
     echo "$USERNAME:$PASSWORD" | chpasswd
 	cp -R /root/ArchTitus /home/$USERNAME/
     chown -R $USERNAME: /home/$USERNAME/ArchTitus
-# enter $nameofmachine to /etc/hostname
-	echo $nameofmachine > /etc/hostname
+# enter $NAME_OF_MACHINE to /etc/hostname
+	echo $NAME_OF_MACHINE > /etc/hostname
 else
 	echo "You are already a user proceed with aur installs"
 fi

--- a/3-post-setup.sh
+++ b/3-post-setup.sh
@@ -21,7 +21,7 @@ if [[ -d "/sys/firmware/efi" ]]; then
 fi
 # set kernel parameter for decrypting the drive
 if [[ "${FS}" == "luks" ]]; then
-sed -i "s%GRUB_CMDLINE_LINUX_DEFAULT=\"%GRUB_CMDLINE_LINUX_DEFAULT=\"cryptdevice=UUID=${encryped_partition_uuid}:ROOT root=/dev/mapper/ROOT %g" /etc/default/grub
+sed -i "s%GRUB_CMDLINE_LINUX_DEFAULT=\"%GRUB_CMDLINE_LINUX_DEFAULT=\"cryptdevice=UUID=${ENCRYPTED_PARTITION_UUID}:ROOT root=/dev/mapper/ROOT %g" /etc/default/grub
 fi
 
 echo -e "Installing CyberRe Grub theme..."

--- a/startup.sh
+++ b/startup.sh
@@ -42,14 +42,14 @@ echo -ne "
     3)      luks with btrfs
     0)      exit
 "
-read FS
-case $FS in
+read fs
+case $fs in
 1) set_option FS btrfs;;
 2) set_option FS ext4;;
 3) 
 echo -ne "Please enter your luks password: "
 read -s luks_password # read password without echo
-set_option luks_password $luks_password
+set_option LUKS_PASSWORD $luks_password
 set_option FS luks;;
 0) exit ;;
 *) echo "Wrong option please select again"; filesystem;;
@@ -116,9 +116,9 @@ read ssd_drive
 
 case $ssd_drive in
     y|Y|yes|Yes|YES)
-    echo "mountoptions=noatime,compress=zstd,ssd,commit=120" >> setup.conf;;
+    echo "MOUNT_OPTIONS=noatime,compress=zstd,ssd,commit=120" >> setup.conf;;
     n|N|no|NO|No)
-    echo "mountoptions=noatime,compress=zstd,commit=120" >> setup.conf;;
+    echo "MOUNT_OPTIONS=noatime,compress=zstd,commit=120" >> setup.conf;;
     *) echo "Wrong option. Try again";drivessd;;
 esac
 }
@@ -149,7 +149,7 @@ echo -ne "Please enter your password: \n"
 read -s password # read password without echo
 set_option PASSWORD $password
 read -rep "Please enter your hostname: " nameofmachine
-set_option nameofmachine $nameofmachine
+set_option NAME_OF_MACHINE $nameofmachine
 }
 # More features in future
 # language (){}


### PR DESCRIPTION
Issue that occurred with the username recently made me want to make sure all the variables followed the same naming convention to prevent an issue like that being hard to spot or occur again if people follow the existing standard.

Following standard used for bash with CAPS_GLOBAL and lower_local variable names. 