### PR TITLE
Add input validation

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -80,6 +80,7 @@ Please select key board layout from this list
 "
 select keymap in "${options[@]}"
 do
+# check if selection is part of list, silence error output and use else block for output
 if echo -e '%s\n' "${options[@]}" | grep -Fqw -- $keymap 2> /dev/null; then
     echo -e "\nYour key boards layout: ${keymap} \n"
     set_option KEYMAP $keymap
@@ -123,6 +124,7 @@ options=($(lsblk -n --output TYPE,KNAME,SIZE | awk '$1=="disk"{print "/dev/"$2"|
 select disk in "${options[@]}"
 do
 
+# check if selection is part of list, silence error output and use else block for output
 if echo -e '%s\n' "${options[@]}" | grep -Fqw ${disk} 2> /dev/null; then
     echo -e "\n${disk%|*} selected \n"
     set_option DISK ${disk%|*}

--- a/startup.sh
+++ b/startup.sh
@@ -140,9 +140,20 @@ drivessd
 userinfo () {
 read -p "Please enter your username: " username
 set_option USERNAME ${username,,} # convert to lower case as in issue #109 
-echo -ne "Please enter your password: \n"
-read -s password # read password without echo
-set_option PASSWORD $password
+while true; do
+  echo -ne "Please enter your password: \n"
+  read -s password # read password without echo
+
+  echo -ne "Please repeat your password: \n"
+  read -s password2 # read password without echo
+
+  if [ "$password" = "$password2" ]; then
+    set_option PASSWORD $password
+    break
+  else
+    echo -e "\nPasswords do not match. Please try again. \n"
+  fi
+done
 read -rep "Please enter your hostname: " nameofmachine
 set_option NAME_OF_MACHINE $nameofmachine
 }

--- a/startup.sh
+++ b/startup.sh
@@ -47,10 +47,22 @@ case $fs in
 1) set_option FS btrfs;;
 2) set_option FS ext4;;
 3) 
-echo -ne "Please enter your luks password: "
-read -s luks_password # read password without echo
-set_option LUKS_PASSWORD $luks_password
-set_option FS luks;;
+while true; do
+  echo -ne "Please enter your luks password: \n"
+  read -s luks_password # read password without echo
+
+  echo -ne "Please repeat your luks password: \n"
+  read -s luks_password2 # read password without echo
+
+  if [ "$luks_password" = "$luks_password2" ]; then
+    set_option LUKS_PASSWORD $luks_password
+    set_option FS luks
+    break
+  else
+    echo -e "\nPasswords do not match. Please try again. \n"
+  fi
+done
+;;
 0) exit ;;
 *) echo "Wrong option please select again"; filesystem;;
 esac

--- a/startup.sh
+++ b/startup.sh
@@ -73,7 +73,7 @@ esac
 }
 keymap () {
 # These are default key maps as presented in official arch repo archinstall
-options=(-by -ca -cf -cz -de -dk -es -et -fa -fi -fr -gr -hu -il -it -lt -lv -mk -nl -no -pl -ro -ru -sg -ua -uk -us)
+options=(by ca cf cz de dk es et fa fi fr gr hu il it lt lv mk nl no pl ro ru sg ua uk us)
 PS3="
 Please select key board layout from this list
 
@@ -81,7 +81,7 @@ Please select key board layout from this list
 select keymap in "${options[@]}"
 do
 # check if selection is part of list, silence error output and use else block for output
-if echo -e '%s\n' "${options[@]}" | grep -Fqw -- $keymap 2> /dev/null; then
+if echo -e '%s\n' "${options[@]}" | grep -Fqw $keymap 2> /dev/null; then
     echo -e "\nYour key boards layout: ${keymap} \n"
     set_option KEYMAP $keymap
     break

--- a/startup.sh
+++ b/startup.sh
@@ -99,9 +99,9 @@ read ssd_drive
 
 case $ssd_drive in
     y|Y|yes|Yes|YES)
-    echo "MOUNT_OPTIONS=noatime,compress=zstd,ssd,commit=120" >> setup.conf;;
+    set_option MOUNT_OPTIONS "noatime,compress=zstd,ssd,commit=120";;
     n|N|no|NO|No)
-    echo "MOUNT_OPTIONS=noatime,compress=zstd,commit=120" >> setup.conf;;
+    set_option MOUNT_OPTIONS "noatime,compress=zstd,commit=120";;
     *) echo "Wrong option. Try again";drivessd;;
 esac
 }

--- a/startup.sh
+++ b/startup.sh
@@ -73,39 +73,22 @@ esac
 }
 keymap () {
 # These are default key maps as presented in official arch repo archinstall
-echo -ne "
+options=(-by -ca -cf -cz -de -dk -es -et -fa -fi -fr -gr -hu -il -it -lt -lv -mk -nl -no -pl -ro -ru -sg -ua -uk -us)
+PS3="
 Please select key board layout from this list
-    -by
-    -ca
-    -cf
-    -cz
-    -de
-    -dk
-    -es
-    -et
-    -fa
-    -fi
-    -fr
-    -gr
-    -hu
-    -il
-    -it
-    -lt
-    -lv
-    -mk
-    -nl
-    -no
-    -pl
-    -ro
-    -ru
-    -sg
-    -ua
-    -uk
-    -us
 
 "
-read -p "Your key boards layout:" keymap
-set_option KEYMAP $keymap
+select keymap in "${options[@]}"
+do
+if echo -e '%s\n' "${options[@]}" | grep -Fqw -- $keymap 2> /dev/null; then
+    echo -e "\nYour key boards layout: ${keymap} \n"
+    set_option KEYMAP $keymap
+    break
+else
+    echo -e "\nInvalid selection, please try again. \n"
+fi
+
+done
 }
 
 drivessd () {
@@ -137,13 +120,12 @@ echo -ne "
 PS3='
 Select the disk to install on: '
 options=($(lsblk -n --output TYPE,KNAME,SIZE | awk '$1=="disk"{print "/dev/"$2"|"$3}'))
-select opt in "${options[@]}"
+select disk in "${options[@]}"
 do
 
-# Positive check
-if echo -e '%s\n' "${options[@]}" | grep -Fqw ${opt} 2> /dev/null; then
-    echo -e "\n${opt%|*} selected \n"
-    echo "DISK=${opt%|*}" >> setup.conf
+if echo -e '%s\n' "${options[@]}" | grep -Fqw ${disk} 2> /dev/null; then
+    echo -e "\n${disk%|*} selected \n"
+    set_option DISK ${disk%|*}
     break
 else
     echo -e "\nInvalid selection, please try again. \n"
@@ -152,7 +134,6 @@ fi
 done
 
 drivessd
-set_option DISK $option
 }
 userinfo () {
 read -p "Please enter your username: " username

--- a/startup.sh
+++ b/startup.sh
@@ -125,19 +125,31 @@ esac
 
 # selection for disk type
 diskpart () {
-# show disks present on system
-lsblk -n --output TYPE,KNAME,SIZE | awk '$1=="disk"{print NR,"/dev/"$2" - "$3}' # show disks with /dev/ prefix and size
 echo -ne "
 ------------------------------------------------------------------------
-    THIS WILL FORMAT AND DELETE ALL DATA ON THE DISK             
-    Please make sure you know what you are doing because         
-    after formating your disk there is no way to get data back      
+    THIS WILL FORMAT AND DELETE ALL DATA ON THE DISK
+    Please make sure you know what you are doing because
+    after formating your disk there is no way to get data back
 ------------------------------------------------------------------------
 
-Please enter full path to disk: (example /dev/sda):
 "
-read option
-echo "DISK=$option" >> setup.conf
+
+PS3='
+Select the disk to install on: '
+options=($(lsblk -n --output TYPE,KNAME,SIZE | awk '$1=="disk"{print "/dev/"$2"|"$3}'))
+select opt in "${options[@]}"
+do
+
+# Positive check
+if echo -e '%s\n' "${options[@]}" | grep -Fqw ${opt} 2> /dev/null; then
+    echo -e "\n${opt%|*} selected \n"
+    echo "DISK=${opt%|*}" >> setup.conf
+    break
+else
+    echo -e "\nInvalid selection, please try again. \n"
+fi
+
+done
 
 drivessd
 set_option DISK $option


### PR DESCRIPTION
Adding input validators that prevent script from crashing or continuing with incorrect values entered. 

1) Disk selection is now a selection from lsblk output instead of manual input to prevent as much user error, as possible. Selection must be disk from list before continuing. 
2) Keymap, same as above but with an additional fix that was causing localectl set-keymap to throw error because of leading dash in options.
3) Changed drivessd function to utilize set_option function to prevent echo to conf adding duplicate options on cancel and rerun of script. 
4) Password entry requires second input to verify you entered what you expected correctly and wont continue until both inputs match. 