### PR TITLE
fix timezone

### DIFF
--- a/1-setup.sh
+++ b/1-setup.sh
@@ -49,7 +49,7 @@ echo -ne "
 "
 sed -i 's/^#en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
 locale-gen
-timedatectl --no-ask-password set-timezone ${TIMEZONE}
+ln -s /usr/share/zoneinfo/${TIMEZONE} /etc/localtime
 timedatectl --no-ask-password set-ntp 1
 localectl --no-ask-password set-locale LANG="en_US.UTF-8" LC_TIME="en_US.UTF-8"
 


### PR DESCRIPTION
The current implementation sets up the Timezone correctly, but it's only effective on the install instance of Arch, when you reboot to Archtitus fully installed the Timezone isn't kept.
Setting a symlink manually fixes the issue.

P.S: there is maybe a better way to fix it but I couldn't find it.