### PR TITLE
add some lib32 libraries for nvidia and set icd location in /etc/environment

### DIFF
--- a/1-setup.sh
+++ b/1-setup.sh
@@ -101,8 +101,9 @@ echo -ne "
 # Graphics Drivers find and install
 gpu_type=$(lspci)
 if grep -E "NVIDIA|GeForce" <<< ${gpu_type}; then
-    pacman -S nvidia --noconfirm --needed
+    pacman -S nvidia lib32-nvidia-utils lib32-vulkan-icd-loader --noconfirm --needed
 	nvidia-xconfig
+	echo "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json" >> /etc/environment
 elif lspci | grep 'VGA' | grep -E "Radeon|AMD"; then
     pacman -S xf86-video-amdgpu --noconfirm --needed
 elif grep -E "Integrated Graphics Controller" <<< ${gpu_type}; then


### PR DESCRIPTION
Hello, i installed arch using this script and for some reason every app i opened that needed vulkan crashed (including steam), i attempted to launch steam like this `VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json steam` and install lib32-nvidia-utils then tried to run steam and the games worked fine, i tried adding `VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json` to /etc/environment so i don't have to use it everytime and everything was fine

Note that lib32-nvidia-utils wasn't pre-installed and without it the games would still crash with a vulkan error, i tried running the game with icd location without having `lib32-nvidia-utils` pre-installed and it still crashed, and yes they also crash if you have it installed without adding the ICD location to /etc/environment