### PR TITLE
Revert fstab change

### DIFF
--- a/0-preinstall.sh
+++ b/0-preinstall.sh
@@ -143,6 +143,7 @@ echo -ne "
 -------------------------------------------------------------------------
 "
 pacstrap /mnt base base-devel linux linux-firmware vim nano sudo archlinux-keyring wget libnewt --noconfirm --needed
+genfstab -U /mnt >> /mnt/etc/fstab
 echo "keyserver hkp://keyserver.ubuntu.com" >> /mnt/etc/pacman.d/gnupg/gpg.conf
 cp -R ${SCRIPT_DIR} /mnt/root/ArchTitus
 cp /etc/pacman.d/mirrorlist /mnt/etc/pacman.d/mirrorlist

--- a/3-post-setup.sh
+++ b/3-post-setup.sh
@@ -16,7 +16,6 @@ Final Setup and Configurations
 GRUB EFI Bootloader Install & Check
 "
 source /root/ArchTitus/setup.conf
-genfstab -U /mnt >> /mnt/etc/fstab
 if [[ -d "/sys/firmware/efi" ]]; then
     grub-install --efi-directory=/boot ${DISK}
 fi


### PR DESCRIPTION
Fstab not generating properly in new location, reverted change and fstab generated properly.

Fixes https://github.com/ChrisTitusTech/ArchTitus/issues/199 

@ChrisTitusTech unless you had something in mind for that change. But, it looks like it breaks the BTRFS install, for sure. I tried to just change the new location to  `genfstab -U /mnt >> /etc/fstab`and still didn't work. 