### PR TITLE
added systemctl enable cronie.services

### DIFF
--- a/3-post-setup.sh
+++ b/3-post-setup.sh
@@ -64,6 +64,7 @@ echo -ne "
 -------------------------------------------------------------------------
 "
 systemctl enable cups.service
+systemctl enable cronie.service
 ntpd -qg
 systemctl enable ntpd.service
 systemctl disable dhcpcd.service


### PR DESCRIPTION
The cronie package is installed but the service is not enabled in 3-post-setup.sh.
Therefore I added the line to enable the cronie.services with the script.