### PR TITLE
Removes lightlyshaders-git in aur-pkgs.txt

### DIFF
--- a/pkg-files/aur-pkgs.txt
+++ b/pkg-files/aur-pkgs.txt
@@ -3,7 +3,6 @@ brave-bin
 dxvk-bin
 github-desktop-bin
 lightly-git
-lightlyshaders-git
 mangohud
 mangohud-common
 nerd-fonts-fira-code


### PR DESCRIPTION
Lightlyshaders is now depreciated. It is incompatible with the current version of Plasma (2.23+) used. Also the package fails to build on the AUR.