### PR TITLE
Change to the list of DE/WM's to be auto-populating

### DIFF
--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -281,7 +281,7 @@ aurhelper () {
 desktopenv () {
   # Let the user choose Desktop Enviroment from predefined list
   echo -ne "Please select your desired Desktop Enviroment:\n"
-  options=( `for f in pkg-files/*.txt; do echo "$f" | sed -r "s/.+\/(.+)\..+/\1/"; done` )
+  options=( `for f in pkg-files/*.txt; do echo "$f" | sed -r "s/.+\/(.+)\..+/\1/;/pkgs/d"; done` )
   select_option $? 4 "${options[@]}"
   desktop_env=${options[$?]}
   set_option DESKTOP_ENV $desktop_env

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -281,7 +281,7 @@ aurhelper () {
 desktopenv () {
   # Let the user choose Desktop Enviroment from predefined list
   echo -ne "Please select your desired Desktop Enviroment:\n"
-  options=(gnome kde cinnamon xfce mate budgie lxde deepin openbox server)
+  options=( `for f in pkg-files/*.txt; do echo "$f" | sed -r "s/.+\/(.+)\..+/\1/"; done` )
   select_option $? 4 "${options[@]}"
   desktop_env=${options[$?]}
   set_option DESKTOP_ENV $desktop_env


### PR DESCRIPTION
The way it is now the list of DE/WM's are hardcoded, so we would need to edit script files to add or remove some of DE/WM's. After this change, it will auto-populate from the .txt files in pkg-files folder. So, to add cutefish, as example, we would only need to add cutefish.txt, and populate it with packages needed... To remove unneeded DE's, only delete .txt file that you don't want listed. Also, script is not showing aur-pkgs and pacman-pkgs in the list (of course) :)