### PR TITLE
Fix typo in gnome-extra package name

### DIFF
--- a/pkg-files/gnome.txt
+++ b/pkg-files/gnome.txt
@@ -1,3 +1,3 @@
 gnome
 --END OF MINIMAL INSTALL--
-gnome-extras
+gnome-extra


### PR DESCRIPTION
"gnome-extras" package does not exist and this causes errors while installing.